### PR TITLE
Add 'namespace' to terminology

### DIFF
--- a/xml/docu_styleguide.terminology.xml
+++ b/xml/docu_styleguide.terminology.xml
@@ -1004,6 +1004,11 @@
       <entry>noun</entry>
      </row>
      <row>
+      <entry>namespace</entry>
+      <entry>name space, name-space</entry>
+      <entry>noun</entry>
+     </row>
+     <row>
       <entry>need to</entry>
       <entry>have to</entry>
       <entry>verb; see also <emphasis>must</emphasis>


### PR DESCRIPTION
We should add the term 'namespace' to the terminology table as it bears plenty opportunities to spell it wrong (name space, name-space).