### PR TITLE
Add pre as identifier for prefaces

### DIFF
--- a/xml/docu_styleguide.structure.xml
+++ b/xml/docu_styleguide.structure.xml
@@ -1293,6 +1293,14 @@ xml:id="tab.install.source"</screen>
      </row>
      <row>
       <entry>
+       <tag class="emptytag">preface</tag>
+      </entry>
+      <entry>
+       <tag class="attvalue">pre</tag>
+      </entry>
+     </row>
+     <row>
+      <entry>
        <tag class="emptytag">procedure</tag>
       </entry>
       <entry>


### PR DESCRIPTION
Currently we have some prefaces identified as "preface.foo" and others as "pre.bar". We should unify this in the Style Guide to avoid further confusion.