### PR TITLE
Add default 'width' attributes for screenshots

### DIFF
--- a/xml/docu_styleguide.structure.xml
+++ b/xml/docu_styleguide.structure.xml
@@ -1059,8 +1059,8 @@ will be displayed in &lt;emphasis role="bold"&gt;bold&lt;/emphasis&gt;</screen>
     <listitem>
      <para>
       Use grayscale font antialiasing (default on SUSE operating systems).
-      Subpixel font antialiasing creates colored letter edges when zoomed or
-      printed.
+      Subpixel font antialiasing (default on Windows and macOS operating
+      systems) creates colored letter edges when zoomed or printed.
      </para>
     </listitem>
     <listitem>

--- a/xml/docu_styleguide.structure.xml
+++ b/xml/docu_styleguide.structure.xml
@@ -1024,6 +1024,33 @@ will be displayed in &lt;emphasis role="bold"&gt;bold&lt;/emphasis&gt;</screen>
     </listitem>
     <listitem>
      <para>
+      To ensure readability and consistency, scale screenshots with the
+      <literal>width</literal> attribute. Choose the appropriate scaling from
+      the following list:
+     </para>
+     <itemizedlist>
+      <listitem>
+       <para>
+        Screenshots of the whole desktop should be scaled to 90&ndash;99 %
+        page width.
+       </para>
+      </listitem>
+      <listitem>
+       <para>
+        Screenshots of individual application windows should be scaled to
+        75&ndash;99 % page width.
+       </para>
+      </listitem>
+      <listitem>
+       <para>
+        Small windows such as message boxes should be scaled to
+        50&ndash;60 % page width.
+       </para>
+      </listitem>
+     </itemizedlist>
+    </listitem>
+    <listitem>
+     <para>
       Create screenshots that are recognizable to readers. For example,
       create screenshots of KDE applications on a KDE desktop with the
       default KDE theme and disable toolbar modifications you have made.


### PR DESCRIPTION
As discussed last week, I'm proposing default values for the 'width' attributes of screenshots

* 100% for fullscreen shots
* 75% for application windows
* 50% for dialogs