### PR TITLE
Add hint to always keep capitalization of UI items [title updated for posterity]

### DIFF
--- a/xml/docu_styleguide.language.xml
+++ b/xml/docu_styleguide.language.xml
@@ -452,7 +452,16 @@
    require more specific wording.
   </para>
   <para>
-   For instructions concerning markup, refer to
+   When referring to UI labels, capitalize them exactly as in the UI itself.
+   Software created at &suse; (such as YaST or Uyuni) should use
+   sentence-style capitalization.
+   If it does not, you can make aware the developers of that software.
+   For more information about sentence-style capitalization, see
+   <xref linkend="sec-capitalization-sentence"/> and the
+   <link xlink:href="https://productbrand.suse.com/writing/conventions-and-rules">&suse; Product Brand guide</link>.
+  </para>
+  <para>
+   For more information about markup for UI labels, see
    <xref linkend="sec-ui-item-markup"/>.
   </para>
  </sect2>


### PR DESCRIPTION
This came out of a discussion between Tanja and me, please review and give thumbs-up/down.

The rationale for formatting all UI labels (i.e. guimenu in XML) in sentence case is that we think that is what all SUSE products should be doing anyway (because of the productbrand.suse.com style guide), it's consistent with our own (new) documentation style guide and even in the past, we used to reformat UI labels to match our style for titles (at least in a large number of cases).