### PR TITLE
Authorship information

### DIFF
--- a/xml/MAIN.styleguide.xml
+++ b/xml/MAIN.styleguide.xml
@@ -47,5 +47,6 @@
  <xi:include href="docu_styleguide.asciidoc.xml"/>
  <xi:include href="docu_styleguide.terminology.xml"/>
  <xi:include href="docu_styleguide.changes.xml" condition="changes"/>
+ <xi:include href="docu_styleguide.contributors.xml"/>
  <xi:include href="gfdl.xml"/>
 </article>

--- a/xml/docu_styleguide.contributors.xml
+++ b/xml/docu_styleguide.contributors.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE appendix
+[
+  <!ENTITY % entities SYSTEM "entity-decl.ent">
+    %entities;
+]>
+<appendix xmlns="http://docbook.org/ns/docbook"
+          xmlns:xi="http://www.w3.org/2001/XInclude"
+          xmlns:xlink="http://www.w3.org/1999/xlink"
+          version="5.0" xml:id="sec-contributor">
+ <title>Contributors</title>
+
+ <para>
+  For a list of people who contributed to this document, visit
+  <link xlink:href="https://github.com/SUSE/doc-styleguide/graphs/contributors">the
+  <guimenu>Contributors</guimenu> page of our Git repository</link>.
+ </para>
+</appendix>

--- a/xml/docu_styleguide.outline.xml
+++ b/xml/docu_styleguide.outline.xml
@@ -89,17 +89,6 @@
       </listitem>
       <listitem>
        <formalpara>
-        <title>Authorship information</title>
-        <para>
-         Create a separate file <filename>authors.xml</filename> and add an
-         <tag class="emptytag">authorgroup</tag>
-         listing all authors and contributors inside it. Include this file
-         with an XInclude.
-        </para>
-       </formalpara>
-      </listitem>
-      <listitem>
-       <formalpara>
         <title>Copyright notice</title>
         <para>
          Use the standard copyright notice reproduced below. Change the
@@ -305,6 +294,23 @@
      <para>
       The optional glossary contains important terms in alphabetical order
       and provides a brief explanation for each.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term>Contributors</term>
+    <listitem>
+     <para>
+      Writing documentation is a collaborative effort. To also give credit to
+      external contributors, add an appendix to the guides, which points to the
+      <guimenu>Contributors</guimenu> page for the respective GitHub
+      repository. For an example, see <xref linkend="sec-contributor"/>.
+     </para>
+     <para>
+      For articles and small documents (such as &suse; Best Practices) whose
+      content is created and maintained by five or fewer contributors, all of
+      whom are from outside the documentation team, credit the contributors
+      on the title page.
      </para>
     </listitem>
    </varlistentry>


### PR DESCRIPTION
Proposal to list contributors to guides in appendix, except for SUSE Best Practices and other one-off articles.