### PR TITLE
terminology: Add a spelling for "lifecycle"

### DIFF
--- a/xml/docu_styleguide.terminology.xml
+++ b/xml/docu_styleguide.terminology.xml
@@ -818,6 +818,13 @@
       <entry>verb</entry>
      </row>
      <row>
+      <entry>lifecycle</entry>
+      <entry>life cycle, life-cycle</entry>
+      <entry>noun; a series of development and support stages that a product
+        passes through
+      </entry>
+     </row>
+     <row>
       <entry>Linux</entry>
       <entry>LINUX, linux</entry>
       <entry>noun; spelling according to project standard</entry>


### PR DESCRIPTION
* Merriam-Webster prefers "life cycle"
* the rest of the company (seemingly) prefers "lifecycle"
* Frank demands

Related: #73 