### PR TITLE
Clarify usage of abstracts

### DIFF
--- a/xml/docu_styleguide.outline.xml
+++ b/xml/docu_styleguide.outline.xml
@@ -131,13 +131,14 @@
      </itemizedlist>
     </listitem>
    </varlistentry>
-   <varlistentry>
+   <varlistentry xml:id="vle-abstract">
     <term>Abstract</term>
     <listitem>
      <para>
       Use an abstract to summarize the information provided in a book,
-      article, or set in five or fewer sentences. Summarize the topic
-      instead of summarizing the outline.
+      article, chapter, or set in five or fewer sentences. Do not use lists,
+      images or examples in an abstract. Summarize the topic instead of
+      summarizing the outline.
      </para>
      <example xml:id="ex-abstract">
       <title>An abstract</title>
@@ -152,7 +153,7 @@
      </example>
     </listitem>
    </varlistentry>
-   <varlistentry>
+   <varlistentry xml:id="vle-toc">
     <term>Table of contents</term>
     <listitem>
      <para>
@@ -160,7 +161,7 @@
      </para>
     </listitem>
    </varlistentry>
-   <varlistentry>
+   <varlistentry xml:id="vle-preface">
     <term>Preface</term>
     <listitem>
      <para>
@@ -170,7 +171,7 @@
      </para>
     </listitem>
    </varlistentry>
-   <varlistentry>
+   <varlistentry xml:id="vle-part">
     <term>Parts</term>
     <listitem>
      <para>
@@ -182,7 +183,7 @@
      </para>
     </listitem>
    </varlistentry>
-   <varlistentry>
+   <varlistentry xml:id="vle-chapter">
     <term>Chapters</term>
     <listitem>
      <para>
@@ -190,6 +191,17 @@
       should be regarded an exception):
      </para>
      <itemizedlist>
+      <listitem>
+       <formalpara>
+        <title>Abstract</title>
+        <para>
+         Use an abstract to summarize the information provided in a book,
+         article, chapter, or set in five or fewer sentences. Summarize the
+         topic instead of summarizing the outline. See also <xref
+          linkend="vle-abstract"/>.
+        </para>
+       </formalpara>
+      </listitem>
       <listitem>
        <formalpara>
         <title>Highlights</title>

--- a/xml/docu_styleguide.outline.xml
+++ b/xml/docu_styleguide.outline.xml
@@ -208,44 +208,9 @@
       </listitem>
       <listitem>
        <formalpara>
-        <title>Highlights</title>
-        <para>
-         Use a highlights section to summarize the information provided in a
-         chapter in four or fewer bullet points. Summarize the topic instead
-         of summarizing the outline.
-        </para>
-       </formalpara>
-       <example xml:id="ex-highlight">
-        <title>A highlights section</title>
-        <para>
-         This chapter will:
-        </para>
-        <itemizedlist>
-         <listitem>
-          <para>
-           Give you an overview over the file systems available in
-           <phrase role="productname">&suse; Linux Enterprise</phrase>, such
-           as Ext3, Ext4, and Btrfs.
-          </para>
-         </listitem>
-         <listitem>
-          <para>
-           Inform you about their distinctive advantages and disadvantages.
-          </para>
-         </listitem>
-         <listitem>
-          <para>
-           Help you choose the right one for your purpose.
-          </para>
-         </listitem>
-        </itemizedlist>
-       </example>
-      </listitem>
-      <listitem>
-       <formalpara>
         <title>Introduction</title>
         <para>
-         Provide introductory information directly after the highlights.
+         Provide introductory information directly after the abstract.
          Do not place it in a separate section.
         </para>
        </formalpara>

--- a/xml/docu_styleguide.outline.xml
+++ b/xml/docu_styleguide.outline.xml
@@ -136,7 +136,7 @@
     <listitem>
      <para>
       Use an abstract to summarize the information provided in a book,
-      article, chapter, or set in five or fewer sentences. Do not use lists,
+      article, chapter, or set in 70&ndash;150 characters. Do not use lists,
       images or examples in an abstract. Summarize the topic instead of
       summarizing the outline.
      </para>
@@ -196,9 +196,13 @@
         <title>Abstract</title>
         <para>
          Use an abstract to summarize the information provided in a book,
-         article, chapter, or set in five or fewer sentences. Summarize the
+         article, chapter, or set in 70&ndash;150 characters. Summarize the
          topic instead of summarizing the outline. See also <xref
-          linkend="vle-abstract"/>.
+         linkend="vle-abstract"/>.
+         <remark>cwickert 2021-12-09: The 70&ndash;155 chars range is taken from
+          <link xlink:href="https://www.contentkingapp.com/academy/meta-description/"/>,
+          we try to play it safe, thus reducing maximum character count by 5 to just 150.
+         </remark>
         </para>
        </formalpara>
       </listitem>


### PR DESCRIPTION
This came up in the context of various bug reports about truncated chapter 'previews' both in the part overview pages and the single page HTML. Turns out the chapters lacked an abstract. We then use the first paragraph instead, but if longer than 500 (?) chars, it gets truncated.

This PR strives to give more guidance for abstracts, mainly that they are also required for chapters.