### PR TITLE
structure: Don't add ID prefixes to SEO-relevant elements

### DIFF
--- a/xml/docu_styleguide.structure.xml
+++ b/xml/docu_styleguide.structure.xml
@@ -1259,10 +1259,18 @@ will be displayed in &lt;emphasis role="bold"&gt;bold&lt;/emphasis&gt;</screen>
       <formalpara>
        <title>Prefix</title>
        <para>
-        Signifies the type of XML element. Use in accordance with
-        <xref linkend="tab-id-prefix"/>.
+        Signifies the type of XML element.
+        Prefixes are meant as an aid to writers to allow creating
+        logically-named, but distinct identifiers even for closely related
+        elements.
+        Use identifiers in accordance with <xref linkend="tab-id-prefix"/>.
        </para>
       </formalpara>
+      <para>
+       Do not add prefixes to identifiers for XML elements that are used to
+       determine the name of HTML pages (such as section and chapter elements).
+       Such exposure of identifiers can hurt SEO.
+      </para>
      </listitem>
      <listitem>
       <formalpara>
@@ -1286,8 +1294,8 @@ will be displayed in &lt;emphasis role="bold"&gt;bold&lt;/emphasis&gt;</screen>
     </orderedlist>
     <example>
      <title>Examples of identifiers</title>
-<screen>xml:id="cha-install"
-xml:id="sec-install-yast"
+<screen>xml:id="install"
+xml:id="install-yast"
 xml:id="tab-install-source"</screen>
     </example>
    </listitem>
@@ -1297,8 +1305,11 @@ xml:id="tab-install-source"</screen>
      longer terms over non-obvious abbreviations. Always use the singular of
      nouns and the infinitive of verbs. For example, a section about
      installing with <phrase role="productname">YaST</phrase> could be
-     called
-     <tag class="attvalue">sec-install-yast</tag>.
+     called <tag class="attvalue">install-yast</tag>.
+    </para>
+    <para>
+     A figure in that section showing language selection could use the
+     identifier <tag class="attvalue">fig-install-yast-language</tag>.
     </para>
    </listitem>
    <listitem>
@@ -1331,7 +1342,7 @@ xml:id="tab-install-source"</screen>
        <tag class="emptytag">appendix</tag>
       </entry>
       <entry>
-       <tag class="attvalue">app</tag>
+       <emphasis>No prefix</emphasis>
       </entry>
      </row>
      <row>
@@ -1339,7 +1350,7 @@ xml:id="tab-install-source"</screen>
        <tag class="emptytag">book</tag>
       </entry>
       <entry>
-       <tag class="attvalue">book</tag>
+       <emphasis>No prefix</emphasis>
       </entry>
      </row>
      <row>
@@ -1355,7 +1366,7 @@ xml:id="tab-install-source"</screen>
        <tag class="emptytag">chapter</tag>
       </entry>
       <entry>
-       <tag class="attvalue">cha</tag>
+       <emphasis>No prefix</emphasis>
       </entry>
      </row>
      <row>
@@ -1376,8 +1387,15 @@ xml:id="tab-install-source"</screen>
      </row>
      <row>
       <entry>
-       <tag class="emptytag">glossary</tag>,
-                <tag class="emptytag">glossterm</tag>
+       <tag class="emptytag">glossary</tag>
+      </entry>
+      <entry>
+       <emphasis>No prefix</emphasis>
+      </entry>
+     </row>
+     <row>
+      <entry>
+       <tag class="emptytag">glossterm</tag>
       </entry>
       <entry>
        <tag class="attvalue">gl</tag>
@@ -1434,7 +1452,7 @@ xml:id="tab-install-source"</screen>
        <tag class="emptytag">part</tag>
       </entry>
       <entry>
-       <tag class="attvalue">part</tag>
+       <emphasis>No prefix</emphasis>
       </entry>
      </row>
      <row>
@@ -1442,7 +1460,7 @@ xml:id="tab-install-source"</screen>
        <tag class="emptytag">preface</tag>
       </entry>
       <entry>
-       <tag class="attvalue">pre</tag>
+       <emphasis>No prefix</emphasis>
       </entry>
      </row>
      <row>
@@ -1466,9 +1484,11 @@ xml:id="tab-install-source"</screen>
      <row>
       <entry>
        <tag class="emptytag">sect1</tag>,
-              <tag class="emptytag">sect2</tag>, etc.</entry>
+       <tag class="emptytag">sect2</tag>, etc.,
+       <tag class="emptytag">section</tag>
+      </entry>
       <entry>
-       <tag class="attvalue">sec</tag>
+       <emphasis>No prefix</emphasis>
       </entry>
      </row>
      <row>
@@ -1476,7 +1496,7 @@ xml:id="tab-install-source"</screen>
        <tag class="emptytag">set</tag>
       </entry>
       <entry>
-       <tag class="attvalue">set</tag>
+       <emphasis>No prefix</emphasis>
       </entry>
      </row>
      <row>
@@ -1493,6 +1513,14 @@ xml:id="tab-install-source"</screen>
       </entry>
       <entry>
        <tag class="attvalue">tab</tag>
+      </entry>
+     </row>
+     <row>
+      <entry>
+       <tag class="emptytag">topic</tag>
+      </entry>
+      <entry>
+       <emphasis>No prefix</emphasis>
       </entry>
      </row>
      <row>

--- a/xml/docu_styleguide.structure.xml
+++ b/xml/docu_styleguide.structure.xml
@@ -1260,8 +1260,7 @@ will be displayed in &lt;emphasis role="bold"&gt;bold&lt;/emphasis&gt;</screen>
        <title>Prefix</title>
        <para>
         Signifies the type of XML element.
-        Prefixes are meant as an aid to writers to allow creating
-        logically-named, but distinct identifiers even for closely related
+        Prefixes aid writers in creating logically named identifiers for
         elements.
         Use identifiers in accordance with <xref linkend="tab-id-prefix"/>.
        </para>


### PR DESCRIPTION
As discussed in, uh, March 2021: https://confluence.suse.com/x/rgEYKQ