### PR TITLE
Minor fixes of style guide bugs

### DIFF
--- a/xml/docu_styleguide.language.xml
+++ b/xml/docu_styleguide.language.xml
@@ -106,7 +106,7 @@
    &suse; supports the Inclusive Naming Initiative which aims to help avoid
    harmful language.
    When making language choices for documentation, review the initiative's
-   <link xlink:href="https://inclusivenaming.org/language/word-list/">Word List</link>
+   <link xlink:href="https://inclusivenaming.org/language/overview/">Word List</link>
    and the
    <link xlink:href="https://inclusivenaming.org/language/evaluation-framework/">Evaluation Framework</link>.
   </para>

--- a/xml/docu_styleguide.language.xml
+++ b/xml/docu_styleguide.language.xml
@@ -376,7 +376,7 @@
   <para>
    Form clear and direct sentences with 20 words or less. Avoid complicated
    clauses. Make sure that the relationship between subject, verb, and
-   object are clear. Avoid joining sentences with semicolons. Avoid ending
+   object is clear. Avoid joining sentences with semicolons. Avoid ending
    sentences with prepositions.
   </para>
   <para>

--- a/xml/docu_styleguide.manage.xml
+++ b/xml/docu_styleguide.manage.xml
@@ -294,7 +294,7 @@ Kernel since &lt;literal&gt;&amp;sle;&lt;/literal&gt; XYZ.</screen>
   <title>XInclude elements</title>
   <para>
    XInclude elements are used to create modular source files that are easier
-   to work with and can be re-used. When editing a book, create a new source
+   to work with and can be reused. When editing a book, create a new source
    file for every chapter. Later, create a new GeekoDoc file that can serve as
    the central point. In this file, use XInclude elements to reference all
    chapters in the correct order:

--- a/xml/docu_styleguide.name.xml
+++ b/xml/docu_styleguide.name.xml
@@ -36,7 +36,7 @@
   <title>IPv4 addresses</title>
   <para>
    Use addresses from the class C subnet <literal>192.168.255.0</literal>
-   for examples. That is, replace the final <literal>0</literal> by any
+   for examples. That is, replace the final <literal>0</literal> with any
    integer between <literal>0</literal> and <literal>255</literal>. To
    create examples using a larger setup, use addresses from the private
    network ranges. For more information, see

--- a/xml/docu_styleguide.structure.xml
+++ b/xml/docu_styleguide.structure.xml
@@ -941,7 +941,7 @@ will be displayed in &lt;emphasis role="bold"&gt;bold&lt;/emphasis&gt;</screen>
    All referenced image files must have a lowercase alphanumeric file name.
    Provide an appropriate image width using the
    <tag class="attvalue">width</tag>
-   attribute. Always add a
+   attribute. For both figure types, formal and informal, always add a
    <tag class="emptytag">textobject role="description"</tag>
    as in <xref linkend="ex-figure"/> to provide an alternative text for the
    HTML output.

--- a/xml/docu_styleguide.structure.xml
+++ b/xml/docu_styleguide.structure.xml
@@ -1041,7 +1041,7 @@ will be displayed in &lt;emphasis role="bold"&gt;bold&lt;/emphasis&gt;</screen>
         </para>
        </formalpara>
       </entry>
-      <entry><link xlink:href="&tdg;/glossary.html"/>
+      <entry><link xlink:href="&tdg;/imagedata.html"/>
       </entry>
      </row>
      <row>

--- a/xml/docu_styleguide.structure.xml
+++ b/xml/docu_styleguide.structure.xml
@@ -628,7 +628,7 @@ data  home  lost+found  opt     run   srv      tmp&lt;/screen&gt;</screen>
       <listitem>
        <para>
         Remove or replace items that are irrelevant to your goal.
-        For example, replace long file names by shorter ones or remove a table
+        For example, replace long file names with shorter ones or remove a table
         column and replace it with <literal>[...]</literal>.
        </para>
       </listitem>
@@ -639,7 +639,7 @@ data  home  lost+found  opt     run   srv      tmp&lt;/screen&gt;</screen>
        </para>
        <screen>&lt;?dbsuse-fo font-size="<replaceable>SIZE</replaceable>em"?&gt;</screen>
        <para>
-        Replace <replaceable>SIZE</replaceable> by a suitable value, such
+        Replace <replaceable>SIZE</replaceable> with a suitable value, such
         <literal>0.7</literal>. Choose a value between <literal>0.55</literal>
         and <literal>1</literal>. Values outside that range will lead to either
         unreadably small or unsuitably large text.

--- a/xml/docu_styleguide.terminology.xml
+++ b/xml/docu_styleguide.terminology.xml
@@ -1830,7 +1830,7 @@
       <entry>WLAN</entry>
       <entry>Wlan</entry>
       <entry>noun; avoid; use only when referring to wireless LANs that are
-              not IEEE 802.11-based; use <emphasis>Wi-Fi</emphasis>in all other
+              not IEEE 802.11-based; use <emphasis>Wi-Fi</emphasis> in all other
               cases.
             </entry>
      </row>

--- a/xml/docu_styleguide.terminology.xml
+++ b/xml/docu_styleguide.terminology.xml
@@ -1910,7 +1910,7 @@
    <para>
     In addition to the words documented here, make sure to also review the
     Inclusive Naming Initiative's
-    <link xlink:href="https://inclusivenaming.org/language/word-list/">Word List</link>.
+    <link xlink:href="https://inclusivenaming.org/language/overview/">Word List</link>.
    </para>
    <para>
     For more information about word choices, see <xref linkend="sec-bias"/>.

--- a/xml/docu_styleguide.terminology.xml
+++ b/xml/docu_styleguide.terminology.xml
@@ -459,7 +459,7 @@
       <entry/>
       <entry>verb; only when a value needs to be specified and
               <keycap function="enter"/> should be pressed afterward; where
-              possible, replace by <emphasis>specify</emphasis> or
+              possible, replace with <emphasis>specify</emphasis> or
               <emphasis>provide</emphasis>
       </entry>
      </row>


### PR DESCRIPTION
Fixed missing space in Terminology
Fixed verb in 5.16
Fixed spelling in 7.4
Fixed Inclusive Naming Initiative links
Updated the Figures section per #186 
Edited the instances of "replace with/by" for consistency (https://github.com/SUSE/doc-styleguide/issues/108)