### PR TITLE
Style Guide update ('Tag allowlist', 'Tone and voice' sections, use of % sign, new terms)

### DIFF
--- a/xml/docu_styleguide.language.xml
+++ b/xml/docu_styleguide.language.xml
@@ -412,22 +412,21 @@
    exaggerations, but focus on positive aspects.
   </para>
   <para>
-   Use second person (<quote>you</quote>) to refer to the reader. Normally,
+   Use the second person (<quote>you</quote>) to refer to the reader. Normally,
    the reader is the user or administrator who performs the actions described.
-   Do not overuse <quote>you.</quote> It is often understood, especially in
-   directions.
+   For example, <quote>To install all officially released patches that apply to
+   your system, run <command>zypper patch</command></quote>. Do not overuse 
+   <quote>you</quote> and <quote>your</quote>. It is often implied who you are 
+   addressing in the instructions. For example, instead of <quote>Install 
+   <emphasis>package</emphasis> on your system</quote>, just say <quote>Install
+   <emphasis>package</emphasis> on the system</quote>. 
   </para>
   <para>
-   Where possible, use active voice. In active voice, the subject of the
-   sentence performs the verb. For example, <quote>The root user performs
-   administrative tasks</quote> is active voice. <quote>Administrative tasks
-   are performed by the root user</quote> is passive voice.
-  </para>
-  <para>
-   Use passive voice if there is no emphasis on the object of the verb or if
-   the performer of the action is unknown. <quote>A Samba server must be
-   configured in the network</quote> is an example of proper use of passive
-   voice. The emphasis is on the server, not on the person configuring it.
+   Where possible, use active voice. If there is no emphasis on the object of
+   the verb or if the performer of the action is unknown, use passive voice. 
+   <quote>A Samba server must be configured in the network</quote> is an example 
+   of the proper use of passive voice. The emphasis is on the server, not on the 
+   person configuring it.
   </para>
  </sect2>
 

--- a/xml/docu_styleguide.language.xml
+++ b/xml/docu_styleguide.language.xml
@@ -318,6 +318,7 @@
    the number. In measurements, add a non-breaking space
    (<tag class="genentity">nbsp</tag>)
    between the numeral and its corresponding unit abbreviation.
+   Use the % sign when paired with a number, with no space.
   </para>
   <para>
    For more information, see <citetitle>The Chicago Manual of

--- a/xml/docu_styleguide.outline.xml
+++ b/xml/docu_styleguide.outline.xml
@@ -179,8 +179,9 @@
     <term>Chapters</term>
     <listitem>
      <para>
-      Chapters typically consist of the following elements (appendixes should
-      be regarded an exception):
+     Chapter titles should not contain product version numbers which affect 
+     the output of data analytics. Chapters typically consist of the 
+     following elements (appendixes should be regarded an exception):
      </para>
      <itemizedlist>
       <listitem>

--- a/xml/docu_styleguide.structure.xml
+++ b/xml/docu_styleguide.structure.xml
@@ -1577,12 +1577,12 @@ xml:id="tab-install-source"</screen>
    </listitem>
    <listitem>
     <para>
-     If each item in a list consists of a single sentence only, do not use a
-     period at the end of items.
+     Use a period after every list item that is a sentence. Do not use a period 
+     after the items that are not complete sentences.
     </para>
-    <para>
-     If at least one list item consists of two full sentences, end all items
-     in that list with a period.
+    <para>Do not use commas and semicolons to end punctuation. Do not use a full stop 
+     with the last item. Use either all full sentences in your bullet lists 
+     or all fragments. Avoid a mix.
     </para>
    </listitem>
    <listitem>
@@ -1590,7 +1590,7 @@ xml:id="tab-install-source"</screen>
      Wherever possible, use parallel phrasing and grammatical construction
      between list items.
      This provides a pattern that makes it easier to follow the text.
-    </para>
+   </para>
    </listitem>
    <listitem>
     <para>

--- a/xml/docu_styleguide.structure.xml
+++ b/xml/docu_styleguide.structure.xml
@@ -1578,7 +1578,8 @@ xml:id="tab-install-source"</screen>
    <listitem>
     <para>
      Use a period after every list item that is a sentence. Do not use a period 
-     after the items that are not complete sentences.
+     after the items that are not complete sentences. Use either all 
+     full sentences in your bullet lists or all fragments. Avoid a mix.
     </para>
     <para>Do not use commas and semicolons to end punctuation. Do not use a full stop 
      with the last item. Use either all full sentences in your bullet lists 

--- a/xml/docu_styleguide.structure.xml
+++ b/xml/docu_styleguide.structure.xml
@@ -2498,7 +2498,7 @@ xml:id="tab-install-source"</screen>
   </para>
   <para>
    Other types of references to resources are described in
-   <xref linkend="sec-cross-reference"/>, <xref linkend="sec-link-to-susecom"/>, and <xref linkend="sec-link"/>.
+   <xref linkend="sec-cross-reference"/> and <xref linkend="sec-link"/>.
   </para>
  </sect2>
 

--- a/xml/docu_styleguide.structure.xml
+++ b/xml/docu_styleguide.structure.xml
@@ -2498,7 +2498,7 @@ xml:id="tab-install-source"</screen>
   </para>
   <para>
    Other types of references to resources are described in
-   <xref linkend="sec-cross-reference"/> and <xref linkend="sec-link"/>.
+   <xref linkend="sec-cross-reference"/>, <xref linkend="sec-link-to-susecom"/>, and <xref linkend="sec-link"/>.
   </para>
  </sect2>
 

--- a/xml/docu_styleguide.structure.xml
+++ b/xml/docu_styleguide.structure.xml
@@ -2067,67 +2067,6 @@ xml:id="tab-install-source"</screen>
   </table>
  </sect2>
 
- <sect2 xml:id="sec-other-external">
-  <title>References to other external resources</title>
-  <remark>sknorr, 2014-01-22: This section could probably use a better
-        structure instead of this mishmash.
-      </remark>
-  <para>
-   To reference file names, use the
-   <tag class="emptytag">filename</tag>
-   element. To reference e-mail addresses, use the
-   <tag class="emptytag">email</tag>
-   element. In either case, do not include a protocol prefix, that is
-   <literal>file://</literal> or <literal>mailto:</literal>, respectively.
-   See also <xref linkend="sec-file-markup"/>.
-  </para>
-  <para>
-   Reference man pages and info pages in this format:
-  </para>
-  <itemizedlist>
-   <listitem>
-    <para>
-     <quote>the man page of <command>command</command></quote>
-    </para>
-   </listitem>
-   <listitem>
-    <para>
-     <quote>the info page of <command>command</command></quote>
-    </para>
-   </listitem>
-  </itemizedlist>
-  <para>
-   In a situation where the category of the page is needed, append the
-   category in parentheses. Use, for example <quote>(<command>man 9
-   command</command>)</quote>.
-  </para>
-<screen>To learn more about subcommands, see the man page of
-&lt;command&gt;command&lt;/command&gt;.</screen>
-  <para>
-   Insert references to external (non-&suse;) physical books in the format
-   <quote>Title by Author (ISBN #00000000).</quote> Inclusion of the ISBN is
-   optional. Place the title in a
-   <tag class="emptytag">citetitle</tag>
-   element. For example:
-  </para>
-<screen>&lt;citetitle&gt;Lorem Ipsum&lt;/citetitle&gt; by Dolores S. Amet
-(ISBN 0-246-52044-7) is a useful guide.</screen>
-  <para>
-   As an author, where possible, provide language-specific references to
-   translators in XML comments (see also <xref linkend="sec-xml-comment"/>).
-   As a translator, look for corresponding language-specific resources where
-   none have been provided. For URLs, provide only the language-specific
-   version of a site. Use the English version as a fallback.
-   For books, provide the
-   title of the translated version along with the original title if such a
-   translation exists.
-  </para>
-  <para>
-   Other types of references to resources are described in
-   <xref linkend="sec-cross-reference"/> and <xref linkend="sec-link"/>.
-  </para>
- </sect2>
-
  <sect2 xml:id="sec-outline-level">
   <title>Outline levels and sectioning</title>
   <para>
@@ -2500,6 +2439,67 @@ xml:id="tab-install-source"</screen>
     </tbody>
    </tgroup>
   </table>
+ </sect2>
+
+<sect2 xml:id="sec-other-external">
+  <title>References to other external resources</title>
+  <remark>sknorr, 2014-01-22: This section could probably use a better
+        structure instead of this mishmash.
+      </remark>
+  <para>
+   To reference file names, use the
+   <tag class="emptytag">filename</tag>
+   element. To reference e-mail addresses, use the
+   <tag class="emptytag">email</tag>
+   element. In either case, do not include a protocol prefix, that is
+   <literal>file://</literal> or <literal>mailto:</literal>, respectively.
+   See also <xref linkend="sec-file-markup"/>.
+  </para>
+  <para>
+   Reference man pages and info pages in this format:
+  </para>
+  <itemizedlist>
+   <listitem>
+    <para>
+     <quote>the man page of <command>command</command></quote>
+    </para>
+   </listitem>
+   <listitem>
+    <para>
+     <quote>the info page of <command>command</command></quote>
+    </para>
+   </listitem>
+  </itemizedlist>
+  <para>
+   In a situation where the category of the page is needed, append the
+   category in parentheses. Use, for example <quote>(<command>man 9
+   command</command>)</quote>.
+  </para>
+<screen>To learn more about subcommands, see the man page of
+&lt;command&gt;command&lt;/command&gt;.</screen>
+  <para>
+   Insert references to external (non-&suse;) physical books in the format
+   <quote>Title by Author (ISBN #00000000).</quote> Inclusion of the ISBN is
+   optional. Place the title in a
+   <tag class="emptytag">citetitle</tag>
+   element. For example:
+  </para>
+<screen>&lt;citetitle&gt;Lorem Ipsum&lt;/citetitle&gt; by Dolores S. Amet
+(ISBN 0-246-52044-7) is a useful guide.</screen>
+  <para>
+   As an author, where possible, provide language-specific references to
+   translators in XML comments (see also <xref linkend="sec-xml-comment"/>).
+   As a translator, look for corresponding language-specific resources where
+   none have been provided. For URLs, provide only the language-specific
+   version of a site. Use the English version as a fallback.
+   For books, provide the
+   title of the translated version along with the original title if such a
+   translation exists.
+  </para>
+  <para>
+   Other types of references to resources are described in
+   <xref linkend="sec-cross-reference"/> and <xref linkend="sec-link"/>.
+  </para>
  </sect2>
 
  <sect2 xml:id="sec-table">

--- a/xml/docu_styleguide.structure.xml
+++ b/xml/docu_styleguide.structure.xml
@@ -555,8 +555,8 @@ data  home  lost+found  opt     run   srv      tmp&lt;/screen&gt;</screen>
     <listitem>
      <para>
       Do not add empty lines at the beginning or end of screens. They can
-      be cut away by the &suse; stylesheets. However, most other
-      stylesheets do not have such functionality.
+      be cut away by the &suse; style sheets. However, most other
+      style sheets do not have such functionality.
      </para>
     </listitem>
     <listitem>
@@ -1127,20 +1127,20 @@ will be displayed in &lt;emphasis role="bold"&gt;bold&lt;/emphasis&gt;</screen>
      <itemizedlist>
       <listitem>
        <para>
-        Screenshots of the whole desktop should be scaled to 90&ndash;99 %
+        Screenshots of the whole desktop should be scaled to 90&ndash;99%
         page width.
        </para>
       </listitem>
       <listitem>
        <para>
         Screenshots of individual application windows should be scaled to
-        75&ndash;99 % page width.
+        75&ndash;99% page width.
        </para>
       </listitem>
       <listitem>
        <para>
         Small windows such as message boxes should be scaled to
-        50&ndash;60 % page width.
+        50&ndash;60% page width.
        </para>
       </listitem>
      </itemizedlist>

--- a/xml/docu_styleguide.structure.xml
+++ b/xml/docu_styleguide.structure.xml
@@ -1582,8 +1582,7 @@ xml:id="tab-install-source"</screen>
      full sentences in your bullet lists or all fragments. Avoid a mix.
     </para>
     <para>Do not use commas and semicolons to end punctuation. Do not use a full stop 
-     with the last item. Use either all full sentences in your bullet lists 
-     or all fragments. Avoid a mix.
+     with the last item.
     </para>
    </listitem>
    <listitem>

--- a/xml/docu_styleguide.structure.xml
+++ b/xml/docu_styleguide.structure.xml
@@ -918,7 +918,7 @@ will be displayed in &lt;emphasis role="bold"&gt;bold&lt;/emphasis&gt;</screen>
   </para>
   <para>
    Other types of references to resources are described in
-   <xref linkend="sec-cross-reference"/>, <xref linkend="sec-link-to-susecom"/>, and
+   <xref linkend="sec-cross-reference"/> and
    <xref linkend="sec-other-external"/>.
   </para>
  </sect2>

--- a/xml/docu_styleguide.structure.xml
+++ b/xml/docu_styleguide.structure.xml
@@ -918,7 +918,7 @@ will be displayed in &lt;emphasis role="bold"&gt;bold&lt;/emphasis&gt;</screen>
   </para>
   <para>
    Other types of references to resources are described in
-   <xref linkend="sec-cross-reference"/> and
+   <xref linkend="sec-cross-reference"/>, <xref linkend="sec-link-to-susecom"/>, and
    <xref linkend="sec-other-external"/>.
   </para>
  </sect2>

--- a/xml/docu_styleguide.taglist.xml
+++ b/xml/docu_styleguide.taglist.xml
@@ -870,12 +870,12 @@ indexterm
        </screen>
       </entry>
       <entry>
-      <para>Index marker</para>
-      <para>
-       legacy element, do not use for new documentation
-      </para>
+      Index marker
       </entry>
-      <entry>Yes</entry>
+      <entry>
+      <para>
+      Yes
+      </para>
       <para>
       Legacy element, do not use for new documentation
      </para>

--- a/xml/docu_styleguide.taglist.xml
+++ b/xml/docu_styleguide.taglist.xml
@@ -18,15 +18,15 @@
  </para>
  <para>
   The following tables list and describe all DocBook tags used for writing
-  most of the &suse; user documentation. It also shows, which tags are
-  translated and which tags will be blocked for translation, means that those
-  tags stay in English.
-  The tables are divided into four categories, listing the elements of each of
-  the respective category.
+  most of the &suse; user documentation. They also show which tags are
+  translated and which tags will be blocked for translation, which means that
+  those tags stay in English.
+  The tables are divided into four categories, listing the elements of each
+  respective category.
  </para>
  <para>
-  With Geekodoc 2 it is also possible to use the Internazionalization Tag Set
-  (ITS) to explicit indicate if a tag should be translated or not.
+  With Geekodoc 2, it is also possible to use the Internazionalization Tag Set
+  (ITS) to explicitly indicate whether a tag should be translated or not.
   For more information on ITS tags, see <xref linkend="sec-taglist-ITS"/>.
  </para>
  <para>
@@ -46,11 +46,11 @@
  <sect3>
   <title>Meta elements</title>
   <para>
-   All of the elements at the section level and above, and many other elements,
-   include a wrapper for meta-information about the content.
-   The meta-information wrapper is designed to contain bibliographic
-   information about the content (author, title, publisher, and so on) as well
-   as other meta-information such as revision histories, keyword sets, and
+   All the elements at the section level and above, and many other elements,
+   include a wrapper for meta information about the content.
+   The meta information wrapper is designed to contain bibliographic
+   information about the content (author, title, publisher, etc.) as well
+   as other meta information such as revision histories, keyword sets, and
    index terms.
   </para>
  <informaltable>
@@ -145,7 +145,7 @@ info
     <entry>
      <tag class="starttag">info</tag>: Wrapper to contain bibliographic
      information about the content and other meta info.
-     <tag class="starttag">dm:PLACEHOLDER</tag>: SUSE specific info needed by
+     <tag class="starttag">dm:PLACEHOLDER</tag>: SUSE-specific info needed by
      the doc-manager tool and Daps to process and build &suse; user
      documentation.
      </entry>
@@ -236,7 +236,7 @@ subtitle
      </screen>
     </entry>
     <entry>
-     The subtitle of a document. Often used for &suse; Best practices guides
+     The subtitle of a document. Often used for &suse; Best Practices guides
     </entry>
     <entry>Yes</entry>
    </row>
@@ -248,8 +248,8 @@ title
     </entry>
     <entry>
      <para>
-      The text of the title of a section of a document or of a formal
-     block-level element.
+      The text of the title for a section of a document or for a formal
+     block-level element
      </para>
     <para>
      For document titles, such as book, article, and set titles, use
@@ -267,8 +267,8 @@ titleabbrev
      </screen>
     </entry>
     <entry>
-     The abbreviation of a title. Can for example be used to show shorter
-     title in table of contents
+     The abbreviation of a title. For example, it can be used to show shorter
+     titles in the table of contents.
     </entry>
     <entry>Yes</entry>
    </row>
@@ -281,11 +281,11 @@ titleabbrev
   <title>Structure elements</title>
   <note>
    <para>
-    Structure elements are needed to sectioning and structure your Document,
-    such as defining the chapters, appendix, etc.
+    Structure elements are needed for sectioning and structuring your document,
+    such as defining chapters, appendix, etc.
    </para>
    <para>
-    Most structure elements do not need translations. The child elements, like
+    Most structure elements do not need translations. The child elements like
    <tag class="starttag">title</tag> are translated.
    </para>
   </note>
@@ -365,7 +365,7 @@ formalpara
 section
        </screen>
       </entry>
-      <entry>A recursive section, unnumbered.</entry>
+      <entry>A recursive section, unnumbered</entry>
       <entry>No</entry>
      </row>
      <row>
@@ -376,7 +376,7 @@ sect1
  sect3
  ...</screen>
       </entry>
-      <entry>Numbered sections that must be properly nested.</entry>
+      <entry>Numbered sections that must be properly nested</entry>
       <entry>No</entry>
      </row>
      <row>
@@ -469,7 +469,7 @@ calloutlist
       <entry>
        <para>No</para>
        <para>
-        Child lement <tag class="starttag">para</tag> is translated.
+        Child element <tag class="starttag">para</tag> is translated.
        </para>
       </entry>
      </row>
@@ -680,8 +680,8 @@ table
 textobject
        </screen>
       </entry>
-      <entry>Explanatory text for images, to aid blind users and to show when
-       the image cannot be loaded because of an error.</entry>
+      <entry>Explanatory text for images to aid visually impaired users and show
+       when the image cannot be loaded because of an error</entry>
       <entry>Yes</entry>
      </row>
      <row>
@@ -876,6 +876,10 @@ indexterm
       </para>
       </entry>
       <entry>Yes</entry>
+      <para>
+      Legacy element, do not use for new documentation
+     </para>
+    </entry>
      </row>
      <row>
       <entry>
@@ -897,7 +901,7 @@ keycap
       <entry>
        <para>The text printed on a key on a keyboard</para>
        <para>
-        For function keys always use with function, for example: 
+        For function keys, always use with function, for example: 
        &lt;keycap function="control">&lt;/keycap>
        </para>
        </entry>
@@ -1157,13 +1161,13 @@ xref
 <sect2 xml:id="sec-taglist-ITS">
  <title>Using ITS tags</title>
  <para>
-  With Geekodoc 2 it is possible to use the Internationalization Tag Set (ITS)
-  tags to explicit indicate that a tag should be translated or not.
+  With Geekodoc 2, it is possible to use the Internationalization Tag Set (ITS)
+  tags to explicitly indicate that a tag should be translated or not.
  </para>
  <para>
-  For this you need to have the its namespace enabled in the XML file. Make
+  For this, you need to have the ITS namespace enabled in the XML file. Make
   sure the following line is added to the root element:
-  <code>xmlns:its="http://www.w3.org/2005/11/its"</code>
+  <code>xmlns:its="http://www.w3.org/2005/11/its"</code>.
  </para>
  <para>
   For example:

--- a/xml/docu_styleguide.terminology.xml
+++ b/xml/docu_styleguide.terminology.xml
@@ -297,7 +297,7 @@
       <entry>codestream</entry>
       <entry>code stream
             </entry>
-      <entry>noun; stream od code
+      <entry>noun; stream of code
             </entry>
      </row>
      <row>

--- a/xml/docu_styleguide.terminology.xml
+++ b/xml/docu_styleguide.terminology.xml
@@ -419,12 +419,9 @@
       <entry>dialog box, dialog window, dialogue [British], mask [Germanism],
         screen
       </entry>
-      <entry>noun; a page or window that asks you to make one or more decisions
-        before proceeding
-        <remark>sknorr, 2013-09-17: Novell use dialog box, apparently, but
-          that sounds rather colloquial. And then, a dialog doesn't
-          have to be in a box/window, as with Web applications
-        </remark>
+      <entry>noun; a secondary window that gives users progress feedback, 
+             prompts users to perform a command, enter information or select 
+             an option
       </entry>
      </row>
      <row>
@@ -551,6 +548,12 @@
               USB stick
             </entry>
       <entry>noun</entry>
+     </row>
+     <row>
+      <entry>form</entry>
+      <entry/>
+      <entry>noun; a structured window, box, or screen that contains numerous 
+             fields or spaces to enter data</entry>
      </row>
      <row>
       <entry>framebuffer</entry>

--- a/xml/docu_styleguide.terminology.xml
+++ b/xml/docu_styleguide.terminology.xml
@@ -436,7 +436,7 @@
       <entry>combination box, combo box, combobox, dropdown, drop-down,
               drop-down menu, drop-down list box, popover, pull-down menu
             </entry>
-      <entry>noun; GUI element with a list that can opened by
+      <entry>noun; GUI element with a list that can be opened by
               clicking on it, whether combined with a text box or not; if list
               entries start actions, use <emphasis>menu</emphasis> instead
             </entry>

--- a/xml/docu_styleguide.terminology.xml
+++ b/xml/docu_styleguide.terminology.xml
@@ -294,6 +294,13 @@
             </entry>
      </row>
      <row>
+      <entry>codestream</entry>
+      <entry>code stream
+            </entry>
+      <entry>noun; stream od code
+            </entry>
+     </row>
+     <row>
       <entry>(to) coldplug sth. (into sth.)</entry>
       <entry>(to) cold plug sth. (into sth.), (to) cold-plug sth. (into
               sth.), (to) coldadd sth., (to) coldswap sth.
@@ -352,6 +359,13 @@
       <entry>noun; generic term, as in:
               <quote>the YaST control center</quote> or
               <quote>the KDE control center</quote>
+      </entry>
+     </row>
+     <row>
+      <entry>crash dump</entry>
+      <entry>crashdump
+            </entry>
+      <entry>noun>
       </entry>
      </row>
      <row>

--- a/xml/docu_styleguide.xmlformat.xml
+++ b/xml/docu_styleguide.xmlformat.xml
@@ -118,7 +118,7 @@
     <para>
      The title elements <tag class="emptytag">title</tag> and
      <tag class="emptytag">term</tag> are block elements. However, they
-     provoke a stylesheet quirk and should be treated differently. This
+     provoke a style sheet quirk and should be treated differently. This
      avoids superfluous whitespace when used in the context of a
      cross-reference. Format title elements with new lines before the opening
      tag and after the closing tag and make sure they follow the indentation


### PR DESCRIPTION
An update of the 'DocBook tags' section of the style guide (fixed typos and layout).
Fix of style guide bugs in various sections and specification on the use of the % sign per #194.
Added admonition about version numbers in chapter titles per #201
Rearranged sections in "Structure and markup chapter" in alphabetical order #169
Added terms 'codestream' #203, 'crash dump' #188
Updated the wording and examples in the 'Tone and voice' subsection of the style guide per #181
Updated guidance on punctuation to use at the end of list items #139 
Added/updated definitions of form and dialog #19