### PR TITLE
Updated the Structure chapter with file and image naming conventions

### DIFF
--- a/xml/docu_styleguide.structure.xml
+++ b/xml/docu_styleguide.structure.xml
@@ -1817,7 +1817,7 @@ xml:id="tab-install-source"</screen>
      after the items that are not complete sentences. Use either all 
      full sentences in your bullet lists or all fragments. Avoid a mix.
     </para>
-    <para>Do not use commas and semicolons to end punctuation. Do not use a full stop 
+    <para>Do not use commas and semicolons to end punctuation. Do not use a period 
      with the last item.
     </para>
    </listitem>

--- a/xml/docu_styleguide.structure.xml
+++ b/xml/docu_styleguide.structure.xml
@@ -514,7 +514,7 @@ in the directory &lt;filename&gt;/etc/sysconfig&lt;/filename&gt;.</screen>
    <para>
    To assign standard names to files and images in DocBook and AsciiDoc,
    follow the naming conventions at
-   <link xlink:href="https://github.com/SUSE/doc-modular/tree/jjaeger_template-overhaul#readme"/>.
+   <link xlink:href="https://github.com/SUSE/doc-modular/tree/main/templates"/>.
   </para>
   </sect3>
   <sect3 xml:id="sec-placeholder">

--- a/xml/docu_styleguide.structure.xml
+++ b/xml/docu_styleguide.structure.xml
@@ -511,9 +511,11 @@ default 0 <co xml:id="co-default"/></screen>
    </para>
 <screen>Find the log file &lt;filename&gt;configuration.xml&lt;/filename&gt;
 in the directory &lt;filename&gt;/etc/sysconfig&lt;/filename&gt;.</screen>
-   <remark>sknorr, 2014-01-21: this is bad practice, I guess, since one
-          could simply append the file name to the path...
-        </remark>
+   <para>
+   To assign standard names to files and images in DocBook and AsciiDoc,
+   follow the naming conventions at
+   <link xlink:href="https://github.com/SUSE/doc-modular/tree/jjaeger_template-overhaul#readme"/>.
+  </para>
   </sect3>
   <sect3 xml:id="sec-placeholder">
    <title>Placeholders</title>
@@ -2545,7 +2547,7 @@ xml:id="tab-install-source"</screen>
   &lt;/question&gt;
   &lt;answer&gt;
    &lt;para&gt;
-    There are less than 4 GB of space available on the selected partition.
+    There are less than 4 GB of space available on the selected partition.
    &lt;/para&gt;
   &lt;/answer&gt;
  &lt;/qandaentry&gt;
@@ -2707,7 +2709,7 @@ xml:id="tab-install-source"</screen>
   <para>
    In a situation where the category of the page is needed, append the
    category in parentheses. Use, for example <quote>(<command>man 9
-   command</command>)</quote>.
+   command</command>).</quote>
   </para>
 <screen>To learn more about subcommands, see the man page of
 &lt;command&gt;command&lt;/command&gt;.</screen>

--- a/xml/docu_styleguide.structure.xml
+++ b/xml/docu_styleguide.structure.xml
@@ -16,9 +16,9 @@
  </para>
 
  <para>
-  &suse; uses the GeekoDoc Relax NG schema which is compatible with DocBook 5.1.
+  &suse; uses the GeekoDoc Relax NG schema which is compatible with DocBook 5.2.
   For more information about the XML elements described here, see the
-  <citetitle>DocBook 5.1: The Definitive Guide</citetitle> sections listed in
+  <citetitle>DocBook 5.2: The Definitive Guide</citetitle> sections listed in
   <xref linkend="tab-book"/>.
  </para>
 
@@ -1817,8 +1817,7 @@ xml:id="tab-install-source"</screen>
      after the items that are not complete sentences. Use either all 
      full sentences in your bullet lists or all fragments. Avoid a mix.
     </para>
-    <para>Do not use commas and semicolons to end punctuation. Do not use a period 
-     with the last item.
+    <para>Do not use commas and semicolons to end punctuation.
     </para>
    </listitem>
    <listitem>

--- a/xml/entity-decl.ent
+++ b/xml/entity-decl.ent
@@ -8,7 +8,7 @@
 <!ENTITY ses "&suse; Linux Enterprise">
 <!ENTITY sesa "SES">
 
-<!ENTITY tdg "https://tdg.docbook.org/tdg/5.1">
+<!ENTITY tdg "https://tdg.docbook.org/tdg/5.2">
 
 <!ENTITY % sgml.features "IGNORE">
 <!ENTITY % xml.features "INCLUDE">


### PR DESCRIPTION
The Structure and Markup chapter has been updated with the reference to the doc-modular repo that contains Smart Docs file and image naming conventions.