### PR TITLE
Punctuation within quotation marks, Terminology additions and updates

### DIFF
--- a/xml/docu_styleguide.language.xml
+++ b/xml/docu_styleguide.language.xml
@@ -76,7 +76,7 @@
    <title>Latin abbreviations</title>
    <para>
     Do not use Latin abbreviations. Use the full English form: for example,
-    instead of <quote>i.e.,</quote> use <quote>that is</quote>. As an
+    use <quote>that is</quote> instead of <quote>i.e.</quote>. As an
     exception to this rule, the abbreviation <emphasis>etc.</emphasis> is
     allowed.
    </para>

--- a/xml/docu_styleguide.language.xml
+++ b/xml/docu_styleguide.language.xml
@@ -63,7 +63,7 @@
     occurrences of the term in this chapter should then use the acronym.
    </para>
    <para>
-    Create plural forms of acronyms by adding a lowercase <quote>s.</quote>
+    Create plural forms of acronyms by adding a lowercase <quote>s</quote>.
     For example, use <quote>CDs</quote> and <quote>BIOSes.</quote> Never add
     an apostrophe before the <quote>s</quote> or <quote>es.</quote>
    </para>

--- a/xml/docu_styleguide.language.xml
+++ b/xml/docu_styleguide.language.xml
@@ -63,20 +63,20 @@
     occurrences of the term in this chapter should then use the acronym.
    </para>
    <para>
-    Create plural forms of acronyms by adding a lowercase <quote>s</quote>.
+    Create plural forms of acronyms by adding a lowercase <quote>s.</quote>
     For example, use <quote>CDs</quote> and <quote>BIOSes.</quote> Never add
     an apostrophe before the <quote>s</quote> or <quote>es.</quote>
    </para>
    <para>
     For clarity, avoid using possessive forms of acronyms. For example, do not
-    use <quote>XMLʼs specification</quote>.
+    use <quote>XMLʼs specification.</quote>
    </para>
   </sect3>
   <sect3 xml:id="sec-latin">
    <title>Latin abbreviations</title>
    <para>
     Do not use Latin abbreviations. Use the full English form: for example,
-    use <quote>that is</quote> instead of <quote>i.e.</quote>. As an
+    instead of <quote>i.e.,</quote> use <quote>that is</quote>. As an
     exception to this rule, the abbreviation <emphasis>etc.</emphasis> is
     allowed.
    </para>
@@ -129,7 +129,7 @@
     Apply sentence-style capitalization to all running text and all types of
     headings and titles that are part of the document content.
     An example for sentence-style capitalization is
-    <quote>Ceph core components</quote>.
+    <quote>Ceph core components.</quote>
    </para>
   </sect3>
   <sect3 xml:id="sec-capitalization-title">
@@ -279,7 +279,7 @@
   </para>
   <para>
    When it is necessary to refer to file extensions, such as in compound
-   words like <quote>PDF file</quote>, always capitalize the extension.
+   words like <quote>PDF file,</quote> always capitalize the extension.
   </para>
  </sect2>
 
@@ -287,9 +287,9 @@
   <title>Headings</title>
   <para>
    When writing a descriptive section, use a noun-based heading title,
-   for example, <quote>Concepts of Software</quote>.
+   for example, <quote>Concepts of Software.</quote>
    When writing a task-orientated section, use a verb in gerund, for example,
-   <quote>Installing Software</quote>.
+   <quote>Installing Software.</quote>
   </para>
   <para>
    Keep headings short and simple. Do not use both an acronym and the
@@ -439,9 +439,7 @@
    Always let the reader know the objective of an action before describing
    the action itself. As an example, write: <quote>To restore world peace,
    click <guimenu>Shake hands</guimenu>.</quote>
-   <remark>sknorr 2014-01-07: it's hard to take this quote seriously.
-        Find something better.</remark>
-  </para>
+   </para>
  </sect2>
 
  <sect2 xml:id="sec-tense">
@@ -466,11 +464,11 @@
    Use the second person (<quote>you</quote>) to refer to the reader. Normally,
    the reader is the user or administrator who performs the actions described.
    For example, <quote>To install all officially released patches that apply to
-   your system, run <command>zypper patch</command></quote>. Do not overuse 
-   <quote>you</quote> and <quote>your</quote>. It is often implied who you are 
+   your system, run <command>zypper patch</command>.</quote> Do not overuse 
+   <quote>you</quote> and <quote>your.</quote> It is often implied who you are 
    addressing in the instructions. For example, instead of <quote>Install 
-   <emphasis>package</emphasis> on your system</quote>, just say <quote>Install
-   <emphasis>package</emphasis> on the system</quote>. 
+   <emphasis>package</emphasis> on your system,</quote> just say <quote>Install
+   <emphasis>package</emphasis> on the system.</quote> 
   </para>
   <para>
    Where possible, use active voice. If there is no emphasis on the object of
@@ -479,8 +477,8 @@
    of the proper use of passive voice. The emphasis is on the server, not on the 
    person configuring it.
   </para>
-  <para>When giving a recommendation, start with <quote>We recommend</quote>. 
-  Do not use passive phrasings like <quote>It is recommended</quote>.
+  <para>When giving a recommendation, start with <quote>We recommend.</quote> 
+  Do not use passive phrasings like <quote>It is recommended.</quote>
   </para>
  </sect2>
 
@@ -577,8 +575,11 @@
    always provides typographic quotes.
   </para>
   <para>
-   Punctuation directly following the quoted text should be included within
-   the quotation marks, as illustrated in <xref linkend="ex-quote"/>.
+   The period and the comma always go within the quotation marks,
+   as illustrated in <xref linkend="ex-quote"/>. The dash, the semicolon,
+   the colon, the question mark and the exclamation mark go within the
+   quotation marks when they apply to the quoted matter only. They go
+   outside when they apply to the whole sentence.
   </para>
   <example xml:id="ex-quote">
    <title>Quote</title>

--- a/xml/docu_styleguide.language.xml
+++ b/xml/docu_styleguide.language.xml
@@ -105,10 +105,9 @@
   <para>
    &suse; supports the Inclusive Naming Initiative which aims to help avoid
    harmful language.
-   When making language choices for documentation, review the initiative's
-   <link xlink:href="https://inclusivenaming.org/language/overview/">Word List</link>
-   and the
-   <link xlink:href="https://inclusivenaming.org/language/evaluation-framework/">Evaluation Framework</link>.
+   When making language choices for documentation, check the initiative's
+   <link xlink:href="https://inclusivenaming.org/language/evaluation-framework/">Evaluation Framework</link>
+   and its <quote>Word lists.</quote>
   </para>
   <para>
    For more information about avoiding gender bias, see <citetitle>The

--- a/xml/docu_styleguide.manage.xml
+++ b/xml/docu_styleguide.manage.xml
@@ -98,7 +98,7 @@
    <listitem>
     <para>
      To represent special characters that cannot easily be displayed,
-     entered, or memorized.
+     entered or memorized.
     </para>
    </listitem>
    <listitem>
@@ -235,7 +235,7 @@
      <term>General Entities</term>
      <listitem>
       <para>
-       Network IP addresses, host names, and user names.
+       Network IP addresses, host names and user names.
       </para>
      </listitem>
     </varlistentry>
@@ -273,7 +273,7 @@ Kernel since &lt;literal&gt;&amp;sle;&lt;/literal&gt; XYZ.</screen>
        version of a longer product name, append an <literal>a</literal> to
        the end of the entity name. For example, use
        <tag class="genentity">slesa</tag>
-       the acronym <quote>SLES</quote>.
+       the acronym <quote>SLES.</quote>
       </para>
      </listitem>
     </varlistentry>
@@ -313,7 +313,7 @@ Kernel since &lt;literal&gt;&amp;sle;&lt;/literal&gt; XYZ.</screen>
    This means that they must have a single top-level element and must not
    contain elements that are not allowed in GeekoDoc.
    Files that are supposed to be referenced multiple times from within the same
-   set, book, or article must not contain any <tag class="attribute">xml:id</tag>
+   set, book or article must not contain any <tag class="attribute">xml:id</tag>
    attributes.
   </para>
   <para>

--- a/xml/docu_styleguide.outline.xml
+++ b/xml/docu_styleguide.outline.xml
@@ -157,7 +157,7 @@
     <term>Preface</term>
     <listitem>
      <para>
-      Include a brief overview of the content of a manual, related manuals, and
+      Include a brief overview of the content of a manual, related manuals and
       typographical conventions. The preface can also contain information about
       its target audience.
      </para>

--- a/xml/docu_styleguide.structure.xml
+++ b/xml/docu_styleguide.structure.xml
@@ -894,7 +894,7 @@ will be displayed in &lt;emphasis role="bold"&gt;bold&lt;/emphasis&gt;</screen>
   <itemizedlist>
    <listitem>
     <para>
-     Link to credible sources, such as suse.com, upstream projects, or
+     Link to credible sources, such as suse.com, upstream projects or
      developer sites.
      Avoid linking to direct competitors of &suse;.
      Do not link to obvious clickbait sites.
@@ -1797,7 +1797,7 @@ xml:id="tab-install-source"</screen>
    </listitem>
    <listitem>
     <para>
-     A list must contain at least two items. If items are few, short, and simple
+     A list must contain at least two items. If items are few, short and simple
      in structure, consider incorporating them in the flowing text instead
      of creating a list.
     </para>
@@ -1989,7 +1989,7 @@ xml:id="tab-install-source"</screen>
   <sect3 xml:id="sec-ordered-list">
    <title>Ordered lists</title>
    <para>
-    Use ordered lists when items have a strict order, hierarchy, or importance.
+    Use ordered lists when items have a strict order, hierarchy or importance.
     Do not use ordered lists to describe sequential user actions (step-by-step
     instructions).
     For sequential user actions, use a procedure, as described in
@@ -2246,7 +2246,7 @@ xml:id="tab-install-source"</screen>
         <listitem>
          <para>
           <tag class="attvalue">meta</tag>
-          (also known as <keycap>Win</keycap>, <keycap>Windows</keycap>, or
+          (also known as <keycap>Win</keycap>, <keycap>Windows</keycap> or
           <keycap>Super</keycap>)
          </para>
         </listitem>
@@ -2305,7 +2305,7 @@ xml:id="tab-install-source"</screen>
   <title>Outline levels and sectioning</title>
   <para>
    Create sections using the
-   <tag class="emptytag">sect1</tag>, <tag class="emptytag">sect2</tag>, and
+   <tag class="emptytag">sect1</tag>, <tag class="emptytag">sect2</tag> and
    <tag class="emptytag">sect3</tag> elements.
    Avoid outlines that require <tag class="emptytag">sect4</tag>
    and <tag class="emptytag">sect5</tag> elements.
@@ -2706,8 +2706,8 @@ xml:id="tab-install-source"</screen>
   </itemizedlist>
   <para>
    In a situation where the category of the page is needed, append the
-   category in parentheses. Use, for example <quote>(<command>man 9
-   command</command>)</quote>.
+   category in parentheses. For example, use <quote>(<command>man 9
+   command</command>).</quote>
   </para>
 <screen>To learn more about subcommands, see the man page of
 &lt;command&gt;command&lt;/command&gt;.</screen>

--- a/xml/docu_styleguide.taglist.xml
+++ b/xml/docu_styleguide.taglist.xml
@@ -50,7 +50,7 @@
    include a wrapper for meta information about the content.
    The meta information wrapper is designed to contain bibliographic
    information about the content (author, title, publisher, etc.) as well
-   as other meta information such as revision histories, keyword sets, and
+   as other meta information such as revision histories, keyword sets and
    index terms.
   </para>
  <informaltable>
@@ -252,7 +252,7 @@ title
      block-level element
      </para>
     <para>
-     For document titles, such as book, article, and set titles, use
+     For document titles, such as book, article and set titles, use
      title-style capitalization. Apply sentence-style capitalization to all
      running text and all types of headings and titles that are part of the
      document content.
@@ -829,7 +829,7 @@ filename
        </screen>
       </entry>
       <entry>
-       Name of a file or path as well as directories, printers, or
+       Name of a file or path as well as directories, printers or
        flash disks
       </entry>
       <entry>No</entry>

--- a/xml/docu_styleguide.techwriting.xml
+++ b/xml/docu_styleguide.techwriting.xml
@@ -11,7 +11,7 @@
   Technical writing has certain characteristics that make it different from
   other types of writing. Its objective is to provide readers with complex
   information and comprehensive answers they are searching for. The content
-  should be well-structured, clear, and concise. Effective technical
+  should be well-structured, clear and concise. Effective technical
   documentation is straightforward, detailed and focused on problem-solving,
   and there is a specific workflow for its creation:
  </para>
@@ -21,7 +21,7 @@
    <term>Defining the target audience</term>
    <listitem>
     <para>
-     Adjust tone, style, and technicality of the text based on the intended
+     Adjust tone, style and technicality of the text based on the intended
      audience. Keep in mind that not all facts that seem obvious to you will be
      obvious to your readers.
     </para>
@@ -55,12 +55,12 @@
      like typos, unfinished sentences, etc. After self-review, ask for a
      technical review by dedicated specialists. A technical review uncovers
      technical or factual errors like missing or misspelled package names,
-     wrong commands, or forgotten options.
+     wrong commands or forgotten options.
     </para>
     <para>
      Request a peer review which can improve your text and detect any
      structural problems or logical traps. You can then do a spell check, link
-     check, and style check with the DAPS tool.
+     check and style check with the DAPS tool.
     </para>
     <para>
      Finally, ask for a linguistic review that tackles language issues, typos,
@@ -71,6 +71,6 @@
  </variablelist>
  <para>
   For more information on how to produce meaningful content that will rank high
-  on the Web, see <xref linkend="sec-webwriting"/>, and <xref linkend="sec-seo"/>.
+  on the Web, see <xref linkend="sec-webwriting"/> and <xref linkend="sec-seo"/>.
  </para>
  </sect1>

--- a/xml/docu_styleguide.terminology.xml
+++ b/xml/docu_styleguide.terminology.xml
@@ -1022,7 +1022,7 @@
      </row>
      <row>
       <entry>man page</entry>
-      <entry>Man page, Man-page, man page, man-page, manpage</entry>
+      <entry>manual page, Man page, Man-page, man page, man-page, manpage</entry>
       <entry>two words</entry>
      </row>
      <row>

--- a/xml/docu_styleguide.terminology.xml
+++ b/xml/docu_styleguide.terminology.xml
@@ -1965,6 +1965,11 @@
       <entry>noun</entry>
      </row>
      <row>
+        <entry>whitespace</entry>
+        <entry>white-space, white space</entry>
+        <entry>noun</entry>
+       </row>
+     <row>
       <entry>Wi-Fi</entry>
       <entry>Wi fi, Wi-fi, Wifi, wireless fidelity, WLAN</entry>
       <entry>noun; use the <emphasis>Wi-Fi</emphasis> brand name

--- a/xml/docu_styleguide.terminology.xml
+++ b/xml/docu_styleguide.terminology.xml
@@ -260,7 +260,7 @@
      <row>
       <entry>changelog</entry>
       <entry>change log, change-log, ChangeLog</entry>
-      <entry>noun; log of changes to a software</entry>
+      <entry>noun; log of changes to software</entry>
      </row>
      <row>
       <entry>check box</entry>
@@ -963,7 +963,7 @@
      <row>
       <entry>(to) log in to sth.</entry>
       <entry>(to) log in at sth., (to) log into sth.</entry>
-      <entry>verb; for logging in to a software</entry>
+      <entry>verb; for logging in to a device, application, etc.</entry>
      </row>
      <row>
       <entry>(to) log in on sth.</entry>
@@ -1908,7 +1908,7 @@
       <entry>noun; referring to software (usually an operating system)
               running on a virtual computer created by software running on a
               physical computer <emphasis>or</emphasis>
-              virtual computer created with a software running on a physical
+              virtual computer created with software running on a physical
               computer</entry>
      </row>
      <row>
@@ -1917,7 +1917,7 @@
       <entry>verb; running software (usually an operating system) on a
               virtual computer created by software running on a physical computer
               <emphasis>or</emphasis>
-              creating a virtual computer with a software running on a physical
+              creating a virtual computer with software running on a physical
               computer
             </entry>
      </row>

--- a/xml/docu_styleguide.terminology.xml
+++ b/xml/docu_styleguide.terminology.xml
@@ -2079,11 +2079,11 @@
   <note>
    <title>Review the word list of the Inclusive Naming Initiative</title>
    <para>
-    In addition to the words documented here, make sure to also review the
-    Inclusive Naming Initiative's
-    <link xlink:href="https://inclusivenaming.org/language/overview/">Word List</link>.
-   </para>
-   <para>
+    In addition to the words documented here, make sure to also review the 
+    Word lists of the Inclusive Naming Initiative's
+    <link xlink:href="https://inclusivenaming.org/language/evaluation-framework/">Evaluation Framework</link>.</para>
+    </note>
+    <para>
     For more information about word choices, see <xref linkend="sec-bias"/>.
    </para>
   </note>

--- a/xml/docu_styleguide.terminology.xml
+++ b/xml/docu_styleguide.terminology.xml
@@ -393,7 +393,7 @@
       <entry>crash dump</entry>
       <entry>crashdump
             </entry>
-      <entry>noun>
+      <entry>noun
       </entry>
      </row>
      <row>
@@ -1196,7 +1196,7 @@
      <row>
       <entry>on port</entry>
       <entry>at port</entry>
-      <entry>preposition noun</entry>
+      <entry>noun with preposition</entry>
      </row>
      <row>
       <entry>PostScript</entry>
@@ -1253,13 +1253,6 @@
       <entry>noun; a set of coded instructions that enables a machine, 
              especially a computer, to perform a desired sequence of 
              operations</entry>
-     </row>
-     <row>
-      <entry>PXE</entry>
-      <entry>P.X.E., Pixie, pixie, PXE Environment, Pxe, pxe</entry>
-      <entry>noun; acronym for
-              <quote>Preboot Execution Environment</quote>
-      </entry>
      </row>
      <row>
       <entry>proxy</entry>
@@ -1401,27 +1394,27 @@
      <row>
       <entry>(to) save sth. as sth.</entry>
       <entry/>
-      <entry>verb; when either saving a file with a specific name
+      <entry>verb; when saving a file with a specific name
             </entry>
      </row>
      <row>
       <entry>(to) save sth. in sth.</entry>
       <entry/>
-      <entry>verb; when either saving a file on a specific device or file
+      <entry>verb; when saving a file either on a specific device or file
               system
             </entry>
      </row>
      <row>
       <entry>(to) save sth. on sth.</entry>
       <entry/>
-      <entry>verb; when either saving a file on a specific device or file
+      <entry>verb; when saving a file either on a specific device or file
               system
             </entry>
      </row>
      <row>
       <entry>(to) save sth. to sth.</entry>
       <entry/>
-      <entry>verb; when either saving a file to a specific folder
+      <entry>verb; when saving a file to a specific folder
             </entry>
      </row>
      <row>
@@ -2317,9 +2310,9 @@
       </entry>
      </row>
      <row>
-      <entry>with regard to</entry>
-      <entry>as regards, in regard to, with regards to</entry>
-      <entry>conjunction noun preposition</entry>
+      <entry>regarding</entry>
+      <entry>as regards, in regard to, with regard to, with regards to</entry>
+      <entry>preposition</entry>
      </row>
     </tbody>
    </tgroup>

--- a/xml/docu_styleguide.terminology.xml
+++ b/xml/docu_styleguide.terminology.xml
@@ -306,7 +306,7 @@
               <emphasis>quit</emphasis> when
               ending an application normally; always use
               <emphasis>terminate</emphasis> when
-              ending an application forcefully.
+              ending an application forcefully
             </entry>
      </row>
      <row>
@@ -322,7 +322,7 @@
               sth.), (to) coldadd sth., (to) coldswap sth.
             </entry>
       <entry>verb; adding a component or device to a system while the
-              system is off.
+              system is off
             </entry>
      </row>
      <row>
@@ -506,7 +506,7 @@
      <row>
       <entry>EPUB</entry>
       <entry>E-PUB, e-PUB, e-Pub, EPub, Epub, ePUB, ePub</entry>
-      <entry>noun; project logo uses the capitalization <quote>ePub</quote>,
+      <entry>noun; project logo uses the capitalization <quote>ePub,</quote>
                 but the vendor standard is <quote>EPUB</quote>
       </entry>
      </row>
@@ -535,7 +535,7 @@
       <entry>Ethernet card</entry>
       <entry>wired card [sounds as if wires attached to the card are meant]
             </entry>
-      <entry>noun; card that connects to networks via Ethernet.
+      <entry>noun; card that connects to networks via Ethernet
             </entry>
      </row>
      <row>
@@ -580,7 +580,7 @@
      <row>
       <entry>form</entry>
       <entry/>
-      <entry>noun; a structured window, box, or screen that contains numerous 
+      <entry>noun; a structured window, box or screen that contains numerous 
              fields or spaces to enter data</entry>
      </row>
      <row>
@@ -612,7 +612,7 @@
       <entry>G.N.O.M.E., GNU Networked Object Model Environment,
               Gnome
             </entry>
-      <entry>noun; spelling as per project standard; not an acronym.
+      <entry>noun; spelling as per project standard; not an acronym
             </entry>
      </row>
      <row>
@@ -749,7 +749,7 @@
        only for <emphasis>physical</emphasis> sources of installation data for
        products;
        when physicality of the installation source is unclear or unimportant,
-       use the more versatile term <emphasis>installation source</emphasis>;
+       use the more versatile term <emphasis>installation source</emphasis>
       </entry>
      </row>
      <row>
@@ -1100,14 +1100,14 @@
      <row>
       <entry>NFS</entry>
       <entry>N.F.S., NFS file system, Nfs</entry>
-      <entry>noun; often: <quote>NFS client</quote>,
+      <entry>noun; often: <quote>NFS client,</quote>
               <quote>NFS server</quote>
       </entry>
      </row>
      <row>
       <entry>NIS</entry>
       <entry>N.I.S., NIS information service, Nis</entry>
-      <entry>noun; often: <quote>NIS client</quote>,
+      <entry>noun; often: <quote>NIS client,</quote>
               <quote>NIS server</quote>
       </entry>
      </row>
@@ -1977,19 +1977,19 @@
       <entry>noun; use the <emphasis>Wi-Fi</emphasis> brand name
               whenever referring to IEEE 802.11-based networks or access points;
               use <emphasis>WLAN</emphasis> when referring to
-              non-IEEE 802.11-based wireless LANs.
+              non-IEEE 802.11-based wireless LANs
             </entry>
      </row>
      <row>
       <entry>Wi-Fi card</entry>
       <entry>wireless card [card has wires attached to it]</entry>
-      <entry>noun; card that connects to Wi-Fi networks.
+      <entry>noun; card that connects to Wi-Fi networks
             </entry>
      </row>
      <row>
       <entry>Wi-Fi/Bluetooth card</entry>
       <entry>wireless card [card has wires attached to it]</entry>
-      <entry>noun; card that combines a Wi-Fi and a Bluetooth card.
+      <entry>noun; card that combines a Wi-Fi and a Bluetooth card
             </entry>
      </row>
      <row>
@@ -2002,7 +2002,7 @@
       <entry>Wlan</entry>
       <entry>noun; avoid; use only when referring to wireless LANs that are
               not IEEE 802.11-based; use <emphasis>Wi-Fi</emphasis> in all other
-              cases.
+              cases
             </entry>
      </row>
      <row>
@@ -2164,7 +2164,7 @@
       <entry>may</entry>
       <entry>verb; use <emphasis>can</emphasis> to express an ability,
               only use <emphasis>may</emphasis> to express permissions
-              sought/given.
+              sought/given
             </entry>
      </row>
      <row>
@@ -2172,13 +2172,13 @@
       <entry>may</entry>
       <entry>verb; use <emphasis>could</emphasis> to express a
               possibility, only use <emphasis>may</emphasis> to express
-              permissions sought/given.
+              permissions sought/given
             </entry>
      </row>
      <row>
       <entry/>
       <entry>easy [filler], easily</entry>
-      <entry>adjective, adverb; avoid.
+      <entry>adjective, adverb; avoid
             </entry>
      </row>
      <row>
@@ -2186,7 +2186,7 @@
       <entry/>
       <entry>abbreviation; avoid; do not use together with
               <quote>for example</quote> and <quote>such as</quote>; always
-                precede with a comma.
+                precede with a comma
             </entry>
      </row>
      <row>

--- a/xml/docu_styleguide.terminology.xml
+++ b/xml/docu_styleguide.terminology.xml
@@ -2082,7 +2082,6 @@
     In addition to the words documented here, make sure to also review the 
     Word lists of the Inclusive Naming Initiative's
     <link xlink:href="https://inclusivenaming.org/language/evaluation-framework/">Evaluation Framework</link>.</para>
-    </note>
     <para>
     For more information about word choices, see <xref linkend="sec-bias"/>.
    </para>

--- a/xml/docu_styleguide.webwriting.xml
+++ b/xml/docu_styleguide.webwriting.xml
@@ -103,7 +103,7 @@
      <para>
       Search engines pull the title tag, or meta title, from H1, and the meta
       description from the abstract. The number of characters is limited, and
-      the recommended length is 55&ndash;65 characters for meta titles, and
+      the recommended length is 55&ndash;65 characters for meta titles and
       145&ndash;155 characters for meta descriptions. Be sure to optimize your
       headings wherever appropriate by integrating keywords, such as product
       names, into them.
@@ -192,8 +192,8 @@
    </listitem>
    <listitem>
     <para>
-    Keep it clear. Make clear statements and avoid "should", "could", and similar 
-    unprecise words.
+    Keep it clear. Make clear statements and avoid <quote>should,</quote>
+    <quote>could</quote> and similar unprecise words.
     </para>
     </listitem>
     <listitem>

--- a/xml/docu_styleguide.xmlformat.xml
+++ b/xml/docu_styleguide.xmlformat.xml
@@ -32,7 +32,7 @@
    <itemizedlist>
     <listitem>
      <para>
-      Some computer output, computer input, or URIs may run longer and cannot
+      Some computer output, computer input or URIs may run longer and cannot
       be broken.
      </para>
     </listitem>
@@ -68,7 +68,7 @@
     <title>Trailing whitespace:</title>
     <para>
      Avoid introducing trailing whitespace characters such as spaces,
-     protected spaces, or tabs. Many editors have an option to view such
+     protected spaces or tabs. Many editors have an option to view such
      characters. <command>git diff</command> will show newly introduced
      trailing whitespace characters in red.
     </para>
@@ -80,7 +80,7 @@
     <para>
      Block elements are all DocBook elements that create a rectangular visual
      block in the layout, such as <tag class="emptytag">para</tag>,
-     <tag class="emptytag">table</tag>, or <tag class="emptytag">figure</tag>.
+     <tag class="emptytag">table</tag> or <tag class="emptytag">figure</tag>.
      Format block elements with new lines before and after each tag and make
      sure they follow the indentation of the document:
     </para>


### PR DESCRIPTION
The chapter Language has been updated with punctuation rules for quotation marks. The entire style guide has been reviewed accordingly.
Also, some punctuation for simple series has been reviewed throughout the style guide (PR https://github.com/SUSE/doc-styleguide/pull/220).
In the same file, the broken link for Inclusive Naming Initiative has been repaired.
Added 'whitespace' #189 to Terminology.
In Terminology, minor typos were corrected: "save sth as" and other "save" entries, PXE entry duplicate removed, etc.