### PR TITLE
Terminology: Clarify that 'init script' should not be used for systemd

### DIFF
--- a/xml/docu_styleguide.terminology.xml
+++ b/xml/docu_styleguide.terminology.xml
@@ -730,7 +730,7 @@
       <entry>init-script, initscript, initialization script [incorrect,
               when referring to script run by <command>init</command>]</entry>
       <entry>noun; a script run by <command>init</command>; for <phrase
-              role="productname">systemd</phrase> use <emphasis>unit</emphasis>
+              role="productname">systemd</phrase>, use <emphasis>unit</emphasis>
               or <emphasis>unit file</emphasis>
       </entry>
      </row>

--- a/xml/docu_styleguide.terminology.xml
+++ b/xml/docu_styleguide.terminology.xml
@@ -729,7 +729,9 @@
       <entry>init script</entry>
       <entry>init-script, initscript, initialization script [incorrect,
               when referring to script run by <command>init</command>]</entry>
-      <entry>noun; a script run by <command>init</command>
+      <entry>noun; a script run by <command>init</command>; for <phrase
+              role="productname">systemd</phrase> use <emphasis>unit</emphasis>
+              or <emphasis>unit file</emphasis>
       </entry>
      </row>
      <row>


### PR DESCRIPTION
In #216 we already added 'unit' and 'unit file', but part of the original issue #16 was to not use "init script" with systemd. I clarified this.