### PR TITLE
Use suse2022-ns stylesheets

### DIFF
--- a/DC-docu_styleguide
+++ b/DC-docu_styleguide
@@ -4,6 +4,6 @@ MAIN="MAIN.styleguide.xml"
 ROOTID=art-styleguide
 DOCBOOK5_RNG_URI="http://www.docbook.org/xml/5.0/rng/docbookxi.rnc"
 
-STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2021-ns"
+STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2022-ns"
 PROFCONDITION="guide"
 OUTPUTNAME="style-guide"

--- a/DC-docu_styleguide_with_changes
+++ b/DC-docu_styleguide_with_changes
@@ -4,6 +4,6 @@ MAIN="MAIN.styleguide.xml"
 ROOTID=art-styleguide
 DOCBOOK5_RNG_URI="http://www.docbook.org/xml/5.0/rng/docbookxi.rnc"
 
-STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2021-ns"
+STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2022-ns"
 PROFCONDITION="guide;changes"
 OUTPUTNAME="style-guide-with-change-log"


### PR DESCRIPTION
I discovered, the layout of our styleguide uses still some old stylesheets. This PR changes it and uses the suse2022-ns stylesheets.
