### PR TITLE
Update Inline elements table to fix #20, #22

### DIFF
--- a/xml/docu_styleguide.structure.xml
+++ b/xml/docu_styleguide.structure.xml
@@ -926,8 +926,11 @@ will be displayed in &lt;emphasis role="bold"&gt;bold&lt;/emphasis&gt;</screen>
    element to mark up URLs that can be opened with a Web browser, such as
    <link xlink:href="https://www.example.org/"/>. Always add the correct
    protocol prefix (for example, <literal>https://</literal>), otherwise
-   links will not work. Never use
-   <tag>filename</tag>
+   links will not work. If possible, use the secure protocol prefix
+   (<literal>https://</literal>).
+  </para>
+  <para>
+   Never use <tag>filename</tag>
    for a link, as that would both disable the link checker and make the link
    unclickable. Avoid entering a text label between
    <tag class="emptytag">link</tag>

--- a/xml/docu_styleguide.taglist.xml
+++ b/xml/docu_styleguide.taglist.xml
@@ -970,7 +970,8 @@ package
        </screen>
       </entry>
       <entry>
-       Name of a software or application package
+       Name of a software or application package. Replaces
+       <tag class="starttag">systemitem class="resource"</tag>.
       </entry>
       <entry>No</entry>
      </row>

--- a/xml/docu_styleguide.taglist.xml
+++ b/xml/docu_styleguide.taglist.xml
@@ -926,7 +926,7 @@ link
        </screen>
       </entry>
       <entry>
-       A hypertext link
+       A hypertext link. Always use the secure protocol prefix (<literal>https://</literal>).
       </entry>
       <entry>No</entry>
      </row>
@@ -1006,13 +1006,6 @@ productname
        <para>
        The formal name of a product
        </para>
-       <para>
-       When referring to an application, add a
-       &lt;phrase role="productname"/> element around it, for example:
-       </para>
-       <screen>
-&lt;phrase role="productname">LibreOffice&lt;/phrase> is an office suite.
-       </screen>
        </entry>
       <entry>No</entry>
      </row>

--- a/xml/docu_styleguide.taglist.xml
+++ b/xml/docu_styleguide.taglist.xml
@@ -926,7 +926,7 @@ link
        </screen>
       </entry>
       <entry>
-       A hypertext link. Always use the secure protocol prefix (<literal>https://</literal>).
+       A hypertext link. Use the secure protocol prefix (<literal>https://</literal>), if possible.
       </entry>
       <entry>No</entry>
      </row>


### PR DESCRIPTION
Updates the "Inline elements" table in the "DocBook Tags" chapter to fix #20 and #22. 