### PR TITLE
Change docbook tags as  for WorldServer

### DIFF
--- a/xml/docu_styleguide.taglist.xml
+++ b/xml/docu_styleguide.taglist.xml
@@ -406,7 +406,7 @@ sect1
       <entry>Numbered sections that must be properly nested</entry>
       <entry>
        <para>No</para>
-       <para>For TM parser settings set to 'Yes'</para>
+       <para>For TM parser settings, set to <emphasis>Yes</emphasis>.</para>
       </entry>
      </row>
      <row>


### PR DESCRIPTION
Hi Daria,

Vistatec had to change some of the parent tags and make them translatable in order to have the child tags available for translation.
I have changed all affected tags but let's discuss when you are back. Maybe it would make more sense, to add another column to the list. 