### PR TITLE
Updated the Language chapter with info on product names

### DIFF
--- a/xml/docu_styleguide.asciidoc.xml
+++ b/xml/docu_styleguide.asciidoc.xml
@@ -7,10 +7,11 @@
 <sect1 xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.0" xml:id="sec-asciidoc">
  <title>Working With AsciiDoc</title>
 
- <para>
-  This section collects resources on how to use AsciiDoc.
+ <para>To create documentation in the AsciiDoc format, 
+ adhere to the comprehensive guide at <link xlink:href="https://asciidoctor.org/docs/asciidoc-recommended-practices"/>.
  </para>
-
+ <para>We also recommend the guidance on AsciiDoc provided in the
+ <link xlink:href="https://documentation.suse.com/trd/contributors/single-html/suse-trd_contrib-guide/#id-asciidoc/">SUSE Technical Reference Documentation Contributors Guide</link>.</para>
  <para>
   The following things are important when working with AsciiDoc:
  </para>
@@ -22,12 +23,6 @@
     <command>asciidoc</command> (Python) tool. In particular, ignore the
     documentation at <literal>https://powerman.name</literal>.
     <!-- Intentionally not linked. -->
-   </para>
-  </listitem>
-  <listitem>
-   <para>
-    Adhere to
-    <link xlink:href="https://asciidoctor.org/docs/asciidoc-recommended-practices"/>.
    </para>
   </listitem>
   <listitem>

--- a/xml/docu_styleguide.language.xml
+++ b/xml/docu_styleguide.language.xml
@@ -25,15 +25,14 @@
   </para>
 
   <para>
-    The correct spelling of &suse; product names should be listed in the
+    The correct spelling of &suse; product names is listed in the
     terminology table (<xref linkend="app-terminology"/>)
     <emphasis>and</emphasis> in the entities file of the Doc Kit repository at
     <link xlink:href="https://github.com/openSUSE/doc-kit/blob/main/docbook5-book/xml/generic-entities.ent"/>.
-    If a product name is not listed in either spot, refer to the &suse; home
-    page, <link xlink:href="https://www.suse.com"/> and the Marketing
-    department.
+    If a product name is not listed in either spot, refer to the official &suse; 
+    <link xlink:href="https://www.suse.com/products/">Products</link> page and the 
+    Marketing department. Make sure to not use articles in front of product names. 
   </para>
-
   <para>
     When in doubt about a style rule, see <citetitle>The Chicago Manual of
     Style</citetitle>, 15th Edition.


### PR DESCRIPTION
Updated the Language chapter with info on product names #246.

I think it is OK to list the SUSE All Products page as an authoritative source. 
We cannot add a link to the SUSE Writers' Guide because it is not public. 
Also, as far as I understand, we shouldn't provide the link to TermWeb either, at least for now.
