### PR TITLE
Update Terminology table with guidance on since #25 and data #240

### DIFF
--- a/xml/docu_styleguide.terminology.xml
+++ b/xml/docu_styleguide.terminology.xml
@@ -2205,6 +2205,12 @@
             </entry>
      </row>
      <row>
+        <entry>data is</entry>
+        <entry>data are</entry>
+        <entry>noun with verb; use all other verbs in the singular
+              </entry>
+       </row>
+     <row>
       <entry/>
       <entry>easy [filler], easily</entry>
       <entry>adjective, adverb; avoid

--- a/xml/docu_styleguide.terminology.xml
+++ b/xml/docu_styleguide.terminology.xml
@@ -2168,8 +2168,8 @@
      </row>
      <row>
       <entry>because of</entry>
-      <entry>due to, owing to</entry>
-      <entry>preposition</entry>
+      <entry>since, due to, owing to</entry>
+      <entry>preposition; only use <emphasis>since</emphasis> in temporal phrases</entry>
      </row>
      <row>
       <entry>business case</entry>
@@ -2299,6 +2299,11 @@
       <entry/>
       <entry>simple [filler], simply</entry>
       <entry>adjective, adverb; avoid</entry>
+     </row>
+     <row>
+      <entry>(to) simplify sth.</entry>
+      <entry>(to) ease sth., (to) facilitate sth.</entry>
+      <entry>verb; avoid</entry>
      </row>
      <row>
       <entry>(to) simplify sth.</entry>


### PR DESCRIPTION
Added "since" to "Rejected" in the meaning of "because" in the Terminology table per #25.
Added "data is" (and "data are" as Rejected) to the Terminology table per #240 .