### PR TITLE
Add system-wide to terminology

### DIFF
--- a/xml/docu_styleguide.terminology.xml
+++ b/xml/docu_styleguide.terminology.xml
@@ -1712,6 +1712,11 @@
       </entry>
      </row>
      <row>
+        <entry>system-wide</entry>
+        <entry>systemwide, system wide</entry>
+        <entry>adjective</entry>
+       </row>
+     <row>
       <entry>symbolic link</entry>
       <entry>soft link, softlink, symlink [jargon]</entry>
       <entry>only as a noun; as a verb, use


### PR DESCRIPTION
Added 'system-wide' to terminology as it is the preferred spelling in SUSE docs.