### PR TITLE
Correct revhistory example

### DIFF
--- a/xml/docu_styleguide.smartdocs.xml
+++ b/xml/docu_styleguide.smartdocs.xml
@@ -300,10 +300,8 @@ ultrashort description for social media, max. 55 chars&lt;/meta>
 &lt;merge>
   &lt;title>Your title, limit to 55 characters, if possible&lt;/title>
   &lt;subtitle>Subtitle if necessary&lt;/subtitle>
-  &lt;revhistory>
-    &lt;title>Changelog&lt;/title>
+  &lt;revhistory xml:id="rh-MY_ROOTID">
     &lt;revision>
-      &lt;revnumber>2&lt;/revnumber>
       &lt;date>2024-11-11&lt;/date>
       &lt;revdescription>
         &lt;para>
@@ -312,7 +310,6 @@ ultrashort description for social media, max. 55 chars&lt;/meta>
       &lt;/revdescription>
     &lt;/revision>
     &lt;revision>
-      &lt;revnumber>1&lt;/revnumber>
       &lt;date>2024-10-10&lt;/date>
       &lt;revdescription>
         &lt;para>

--- a/xml/docu_styleguide.smartdocs.xml
+++ b/xml/docu_styleguide.smartdocs.xml
@@ -300,7 +300,7 @@ ultrashort description for social media, max. 55 chars&lt;/meta>
 &lt;merge>
   &lt;title>Your title, limit to 55 characters, if possible&lt;/title>
   &lt;subtitle>Subtitle if necessary&lt;/subtitle>
-  &lt;revhistory xml:id="rh-MY_ROOTID">
+  &lt;revhistory xml:id="rh-USE_ROOTID">
     &lt;revision>
       &lt;date>2024-11-11&lt;/date>
       &lt;revdescription>


### PR DESCRIPTION
I found some discrepancies in an example. This PR fixes some issues:

* Add missing `xml:id` on `<revhistory>`
* Remove `<title>` on `<revhistory>` as it's not recommended (will be automatically created)
* Remove `<revnumber>` tags (not really useful for documentation)