### PR TITLE
Update the entry order in Revhistory section #289

### DIFF
--- a/xml/docu_styleguide.smartdocs.xml
+++ b/xml/docu_styleguide.smartdocs.xml
@@ -349,6 +349,9 @@ ultrashort description for social media, max. 55 chars&lt;/meta>
   page. Keep in mind the following rules:</para>
   <itemizedlist>
     <listitem>
+     <para>List revision entries in descending order by date. The latest entry must always come first.</para>
+    </listitem>
+    <listitem>
      <para>Describe only significant changes that you performed.</para>
     </listitem>
     <listitem>


### PR DESCRIPTION
This PR adds the instruction about the order in which to add entries to the Revhistory section as suggested in #289. 