### PR TITLE
Added instruction on when to use the guimenu tag

### DIFF
--- a/xml/docu_styleguide.taglist.xml
+++ b/xml/docu_styleguide.taglist.xml
@@ -905,7 +905,7 @@ guimenu
        </screen>
       </entry>
       <entry>
-       The name of a menu in a GUI
+        To mark up all GUI elements like button, label and menu
       </entry>
       <entry>
        <para>Yes</para>


### PR DESCRIPTION
Added instruction in "DocBook tags" on when to use the `guimenu` tag.