### PR TITLE
Added language rules derived from ASD-STE100

### DIFF
--- a/xml/docu_styleguide.changes.xml
+++ b/xml/docu_styleguide.changes.xml
@@ -12,6 +12,79 @@
     This section lists the changes between versions of this Style Guide.
     </para>-->
   <!-- Add new versions to the beginning of the list. -->
+  <revision xml:id="sec-change-2026-08"><date>2026-08-14</date>
+    <revdescription>
+      <itemizedlist>
+        <listitem>
+          <para>
+            Added a section on paragraph structure: topic sentences, one topic per paragraph, and
+            a maximum of six sentences.
+          </para>
+        </listitem>
+        <listitem>
+          <para>
+            Split the sentence length limit into 25 words for running text and 20 words for
+            procedure steps, and added rules for counting words.
+          </para>
+        </listitem>
+        <listitem>
+          <para>
+            Added a rule to write one instruction per step, in the imperative form.
+          </para>
+        </listitem>
+        <listitem>
+          <para>
+            Clarified that notes and tips give information only and must not contain instructions,
+            requirements, or limits.
+          </para>
+        </listitem>
+        <listitem>
+          <para>
+            Added a section on articles: do not omit articles, do not use an article before a noun
+            with an identifier, and repeat the article in a series if needed.
+          </para>
+        </listitem>
+        <listitem>
+          <para>
+            Added a section on jargon and slang.
+          </para>
+        </listitem>
+        <listitem>
+          <para>
+            Added a section on multi-word nouns with a limit of three words.
+          </para>
+        </listitem>
+        <listitem>
+          <para>
+            Added a section on phrasal verbs, listing the ones that remain accepted.
+          </para>
+        </listitem>
+        <listitem>
+          <para>
+            Added a section on pronouns, including sentence-initial <quote>this</quote> and
+            <quote>that.</quote>
+          </para>
+        </listitem>
+        <listitem>
+          <para>
+            Added a section on terminology consistency: one term for one thing, and consistent
+            phrasing for recurring actions.
+          </para>
+        </listitem>
+        <listitem>
+          <para>
+            Added a section on verbs: do not use names as verbs, prefer verbs over
+            nominalizations, and keep the conjunction <quote>that.</quote>
+          </para>
+        </listitem>
+        <listitem>
+          <para>
+            Added entries for jargon and phrasal verbs to the general vocabulary table.
+          </para>
+        </listitem>
+      </itemizedlist>
+    </revdescription>
+  </revision>
   <revision xml:id="sec-change-2025-12"><date>2025-12-12</date>
     <revdescription>
       <itemizedlist>

--- a/xml/docu_styleguide.changes.xml
+++ b/xml/docu_styleguide.changes.xml
@@ -17,6 +17,11 @@
       <itemizedlist>
         <listitem>
           <para>
+            Updated Web writing chapter with guidelines for GEO and AI search and Web writing in general.
+          </para>
+        </listitem>
+        <listitem>
+          <para>
             Added a section on paragraph structure: topic sentences, one topic per paragraph, and
             a maximum of six sentences.
           </para>
@@ -80,6 +85,28 @@
         <listitem>
           <para>
             Added entries for jargon and phrasal verbs to the general vocabulary table.
+          </para>
+        </listitem>
+      </itemizedlist>
+    </revdescription>
+  </revision>
+  <revision xml:id="sec-change-2026-06"><date>2026-06-22</date>
+    <revdescription>
+      <itemizedlist>
+        <listitem>
+          <para>
+            Streamlined abstract guidelines to a simpler 40–80 word structure designed 
+            to optimize content summaries for humans and AI search.
+          </para>
+        </listitem>
+        <listitem>
+          <para>
+            Added new rules and examples for formatting step-by-step actions and nested lists in AsciiDoc.
+          </para>
+        </listitem>
+        <listitem>
+          <para>
+            Added guidance on using backslashes to keep AsciiDoc attributes from being replaced inside code examples.
           </para>
         </listitem>
       </itemizedlist>

--- a/xml/docu_styleguide.language.xml
+++ b/xml/docu_styleguide.language.xml
@@ -92,6 +92,29 @@
       </para>
     </section>
   </section>
+  <section xml:id="sec-article-language">
+    <title>Articles</title>
+    <para>
+      Do not omit articles to make a sentence shorter. Write <quote>Edit the
+      <filename>/etc/hosts</filename> file.</quote> instead of <quote>Edit file
+      <filename>/etc/hosts</filename>.</quote> Omitted articles are hard to translate and can make
+      a noun string ambiguous.
+    </para>
+    <para>
+      Do not use an article before a noun that is followed by an identifier. The identifier makes
+      the noun specific already. Write <quote>See step 3</quote> instead of <quote>See the step
+      3.</quote>
+    </para>
+    <para>
+      In a series of items, the position of the article changes the meaning. In <quote>Restart the
+      new services, timers, and sockets,</quote> all three are new. In <quote>Restart the new
+      services, the timers, and the sockets,</quote> only the services are new. Repeat the article
+      before every item when the modifier applies to the first item only.
+    </para>
+    <para>
+      Do not use an article before a product name.
+    </para>
+  </section>
   <section xml:id="sec-bias">
     <title>Biases and inclusiveness</title>
     <para>
@@ -343,10 +366,99 @@
       up to date.</quote>
     </para>
   </section>
+  <section xml:id="sec-jargon">
+    <title>Jargon and slang</title>
+    <para>
+      Do not use jargon, slang, or regional expressions. Many of our readers do not have English as
+      a first language, and such terms are hard to translate and easy to misunderstand. Use a plain
+      technical term instead:
+    </para>
+    <itemizedlist>
+      <listitem>
+        <para>
+          Instead of <quote>to brick a device,</quote> write <quote>to make a device
+          unusable.</quote>
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          Instead of <quote>to nuke</quote> or <quote>to blow away,</quote> write <quote>to
+          delete</quote> or <quote>to remove.</quote>
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          Instead of <quote>to spin up an instance,</quote> write <quote>to create an
+          instance</quote> or <quote>to start an instance.</quote>
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          Instead of <quote>out of the box,</quote> write <quote>by default</quote> or
+          <quote>without additional configuration.</quote>
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          Instead of <quote>under the hood,</quote> write <quote>internally.</quote>
+        </para>
+      </listitem>
+    </itemizedlist>
+    <para>
+      Do not use humor, irony, or cultural references, such as references to films, sports, or
+      holidays. They rarely translate and can exclude readers. For more information, see
+      <xref linkend="sec-bias"/>.
+    </para>
+    <para>
+      A technical term is not jargon. Terms such as <literal>container</literal>,
+      <literal>inode</literal>, or <literal>snapshot</literal> are correct in the right context.
+      If a term is new to the intended audience, define it at first use.
+    </para>
+  </section>
   <section xml:id="sec-language-list">
     <title>Lists</title>
     <para>
       For information about creating lists, see <xref linkend="sec-list"/>.
+    </para>
+  </section>
+  <section xml:id="sec-noun-string">
+    <title>Multi-word nouns</title>
+    <para>
+      A multi-word noun is a noun that is modified by other nouns, such as <quote>cluster node
+      configuration file</quote>. Strings of nouns are ambiguous, because the reader cannot see
+      which word modifies which. Use a maximum of three words in a multi-word noun, including the
+      final noun.
+    </para>
+    <para>
+      To shorten a longer noun string, use one of the following methods:
+    </para>
+    <itemizedlist>
+      <listitem>
+        <para>
+          Insert a preposition to show the relationship between the words. Write <quote>the
+          configuration file of the cluster node</quote> instead of <quote>the cluster node
+          configuration file.</quote>
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          Define the term at first use, then use a short form. For example, write <quote>the
+          configuration file of the cluster node (the node configuration)</quote> and use
+          <quote>the node configuration</quote> afterwards. Use the same short form throughout the
+          document. For more information, see <xref linkend="sec-terminology-consistency"/>.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          Hyphenate the words that belong together, if the hyphenated form is established. For
+          example, write <quote>a read-only file system</quote>. For more information, see
+          <xref linkend="sec-hyphens"/>.
+        </para>
+      </listitem>
+    </itemizedlist>
+    <para>
+      This rule does not apply to names that you must not change, such as product names, command
+      names, or user interface labels. Do not shorten or hyphenate them.
     </para>
   </section>
   <section xml:id="sec-number">
@@ -362,6 +474,82 @@
     </para>
     <para>
       For more information, see <citetitle>The Chicago Manual of Style</citetitle> 9.6 and 9.16.
+    </para>
+  </section>
+  <section xml:id="sec-paragraph">
+    <title>Paragraphs</title>
+    <para>
+      Start each paragraph with a topic sentence that states what the paragraph is about. Use the
+      sentences that follow to explain that topic or to add information about it. If you read only
+      the first sentence of every paragraph in a section, you should get a correct outline of the
+      section.
+    </para>
+    <para>
+      Give each paragraph one topic. When you start to describe a second topic, start a new
+      paragraph.
+    </para>
+    <para>
+      Do not write more than six sentences in a paragraph. A longer paragraph usually contains more
+      than one topic. Split it into two paragraphs and give each of them a topic sentence.
+    </para>
+    <para>
+      Short paragraphs with a single topic also help the systems that process our content. Search
+      engines and AI assistants split a page into chunks, and a paragraph that covers one topic
+      stays meaningful when it is retrieved on its own. For more information, see
+      <xref linkend="sec-webwriting"/>.
+    </para>
+  </section>
+  <section xml:id="sec-phrasal-verb">
+    <title>Phrasal verbs</title>
+    <para>
+      A phrasal verb is a verb with a preposition or an adverb, such as <quote>to shut
+      down</quote>. Do not use a phrasal verb if a precise single-word verb exists. Phrasal verbs
+      often have several meanings, which makes them ambiguous and hard to translate:
+    </para>
+    <itemizedlist>
+      <listitem>
+        <para>
+          Instead of <quote>to bring up,</quote> write <quote>to start.</quote>
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          Instead of <quote>to carry out,</quote> write <quote>to perform</quote> or <quote>to
+          run.</quote>
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          Instead of <quote>to figure out,</quote> write <quote>to determine.</quote>
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          Instead of <quote>to look into,</quote> write <quote>to investigate.</quote>
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          Instead of <quote>to go through,</quote> write <quote>to review.</quote>
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          Instead of <quote>to get rid of,</quote> write <quote>to remove</quote> or <quote>to
+          delete.</quote>
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          Instead of <quote>to take out,</quote> write <quote>to remove.</quote>
+        </para>
+      </listitem>
+    </itemizedlist>
+    <para>
+      Some phrasal verbs are the established technical term for an action, and no single-word verb
+      replaces them. Use them as they are listed in <xref linkend="app-terminology"/>, for example
+      <quote>to log in to,</quote> <quote>to set up,</quote> <quote>to shut down,</quote> and
+      <quote>to back up.</quote> Do not replace them with a single-word verb.
     </para>
   </section>
   <section xml:id="sec-possessive">
@@ -380,6 +568,28 @@
     </para>
     <para>
       For more information about using hyphens, see <xref linkend="sec-hyphens"/>.
+    </para>
+  </section>
+  <section xml:id="sec-pronoun">
+    <title>Pronouns</title>
+    <para>
+      Use a pronoun only if the noun that it replaces is unambiguous. If a sentence contains more
+      than one noun that the pronoun can refer to, repeat the noun instead.
+    </para>
+    <para>
+      Do not start a sentence with <quote>this,</quote> <quote>that,</quote> <quote>these,</quote>
+      or <quote>it</quote> to refer to the whole of the previous sentence. Name the thing that you
+      refer to. Write <quote>The service reads the file at start-up. This behavior prevents
+      changes at runtime.</quote> instead of <quote>The service reads the file at start-up. This
+      prevents changes at runtime.</quote>
+    </para>
+    <para>
+      Do not use <quote>it</quote> as an empty subject in a technical statement. Write <quote>The
+      installation takes approximately 10 minutes.</quote> instead of <quote>It takes
+      approximately 10 minutes to install.</quote>
+    </para>
+    <para>
+      For information about gender and pronouns, see <xref linkend="sec-bias"/>.
     </para>
   </section>
   <section xml:id="sec-quotation">
@@ -445,9 +655,83 @@
   <section xml:id="sec-structure-sentence">
     <title>Sentence structure</title>
     <para>
-      Form clear and direct sentences with 25 words or less. Avoid complicated clauses. Make sure
-      that the relationship between subject, verb, and object is clear. Avoid joining sentences
-      with semicolons. Avoid ending sentences with prepositions.
+      Form clear and direct sentences. Avoid complicated clauses. Make sure that the relationship
+      between subject, verb, and object is clear. Avoid joining sentences with semicolons. Avoid
+      ending sentences with prepositions.
+    </para>
+    <para>
+      Keep sentences within the following limits:
+    </para>
+    <itemizedlist>
+      <listitem>
+        <para>
+          In running text, use a maximum of 25 words in a sentence.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          In a step of a procedure, use a maximum of 20 words in a sentence. Readers who follow a
+          procedure read in short glances while they work, so instructions must be shorter than
+          descriptions.<phrase outputformat="db"> See also
+          <xref linkend="sec-procedure"/>.</phrase>
+        </para>
+      </listitem>
+    </itemizedlist>
+    <para>
+      Write one instruction in a step. Use the imperative form: write <quote>Enter the user
+      name.</quote> instead of <quote>The user name must be entered.</quote> Describe two actions
+      in the same step only if the actions occur at the same time, or if a result follows
+      immediately from the action. For example, a command and the output that the command returns
+      belong in the same step.
+    </para>
+    <para>
+      Do not combine <quote>must</quote> with an imperative. Write <quote>Before you remove the
+      disk, unmount the file system.</quote> instead of <quote>Before you remove the disk, you must
+      unmount the file system.</quote> An exception is a safety-critical instruction, where
+      <quote>must</quote> can show the reader that the instruction is important.
+    </para>
+    <para>
+      To check the length of a sentence, count each of the following as one word:
+    </para>
+    <itemizedlist>
+      <listitem>
+        <para>
+          A number, or a number together with its unit of measurement, such as
+          <literal>4 GB</literal>.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          An abbreviation or an acronym.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          A command, an option, a file name, or a path, such as
+          <command>systemctl daemon-reload</command>.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          A user interface label, such as <guimenu>User and group management</guimenu>.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          A hyphenated compound, such as <emphasis>read-only</emphasis>.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          Text in parentheses. Count the text in the parentheses a second time, as a sentence of
+          its own.
+        </para>
+      </listitem>
+    </itemizedlist>
+    <para>
+      Do not count numbers that identify steps, sections, or figures. A colon that introduces a
+      list ends the sentence: count the text before the colon as one sentence and each list item as
+      a separate sentence. The word limit applies to each of them.
     </para>
     <para>
       Avoid using parentheses. Where they are necessary, move them to the end of the sentence.
@@ -472,6 +756,31 @@
       Use the simple present tense. Apply the simple present tense even to sentences with
       <quote>if</quote> or <quote>when</quote> clauses and to prerequisites of an action. For
       example, <quote>If this happens, go there.</quote> or <quote>Glibc is installed.</quote>
+    </para>
+  </section>
+  <section xml:id="sec-terminology-consistency">
+    <title>Terminology consistency</title>
+    <para>
+      Use one term for one thing, and use that term every time you refer to that thing. Do not
+      use synonyms for variety. If you write <quote>cluster node,</quote> do not switch to
+      <quote>cluster member</quote> or <quote>machine</quote> later in the document. A reader who
+      sees a different term assumes that you describe a different thing.
+    </para>
+    <para>
+      In the same way, do not use one term for two things. If <quote>host</quote> means the
+      physical machine, do not also use it for a host name entry.
+    </para>
+    <para>
+      For approved terms, see <xref linkend="app-terminology"/> and the &suse; official
+      terminology database, <link xlink:href="https://suse.termweb.eu/">TermWeb</link>. If a term
+      is not listed, choose one spelling and apply it consistently in the document.
+    </para>
+    <para>
+      Use the same phrasing for actions that recur. For example, always write <quote>Confirm with
+      <guimenu>OK</guimenu>.</quote> or always write <quote>Click
+      <guimenu>OK</guimenu>.</quote>&mdash;do not alternate between them. Consistent phrasing lets
+      translation memory reuse existing translations, which reduces cost and keeps the translated
+      documentation consistent.
     </para>
   </section>
   <section xml:id="sec-tone">
@@ -554,6 +863,32 @@
     <para>
       For more information about markup for UI labels, see
       <xref linkend="sec-ui-item-markup" outputformat="db"/><xref linkend="sec-ui-item-markup-adoc" outputformat="adoc"/>.
+    </para>
+  </section>
+  <section xml:id="sec-verb">
+    <title>Verbs</title>
+    <para>
+      Do not use a product name, a command name, or a user interface label as a verb. Write
+      <quote>Use <command>rsync</command> to copy the directory.</quote> instead of <quote>Rsync
+      the directory.</quote> Names are nouns, and a reader who does not know the name cannot see
+      which action you describe.
+    </para>
+    <para>
+      Use a verb to describe an action. Do not turn the action into a noun. Write <quote>Before
+      you remove the disk, unmount the file system.</quote> instead of <quote>Before the removal
+      of the disk, perform an unmount of the file system.</quote> A verb makes the sentence
+      shorter and shows who performs the action.
+    </para>
+    <para>
+      Keep the conjunction <quote>that</quote> after verbs such as <quote>make sure,</quote>
+      <quote>note,</quote> and <quote>verify.</quote> Write <quote>Make sure that the service is
+      running.</quote> instead of <quote>Make sure the service is running.</quote> Without
+      <quote>that,</quote> the reader can first read the following noun as the object of the verb.
+    </para>
+    <para>
+      For information about tense, see <xref linkend="sec-tense"/>. For information about active
+      and passive voice, see <xref linkend="sec-tone"/>. For information about phrasal verbs, see
+      <xref linkend="sec-phrasal-verb"/>.
     </para>
   </section>
 </chapter>

--- a/xml/docu_styleguide.language.xml
+++ b/xml/docu_styleguide.language.xml
@@ -741,7 +741,8 @@
     <para>
       For approved terms, see <xref linkend="app-terminology"/> and the &suse; official
       terminology database, <link xlink:href="https://suse.termweb.eu/">TermWeb</link>. If a term
-      is not listed, choose one spelling and apply it consistently in the document.
+      is not listed, choose one spelling and apply it consistently in the document. You can also
+suggest missing terms using the feedback form in TermWeb.
     </para>
     <para>
       Use the same phrasing for actions that recur. For example, always write <quote>Confirm with

--- a/xml/docu_styleguide.language.xml
+++ b/xml/docu_styleguide.language.xml
@@ -8,6 +8,51 @@
   <title>Language</title>
   <info>
     <revhistory xml:id="rh-language">
+      <revision><date>2026-08-14</date>
+        <revdescription>
+          <itemizedlist>
+            <listitem>
+            <para>
+              Added a section on articles: do not omit articles, do not use an article before a noun
+              with an identifier, and repeat the article in a series if needed.
+            </para>
+          </listitem>
+          <listitem>
+            <para>
+              Added a section on jargon and slang.
+            </para>
+          </listitem>
+          <listitem>
+            <para>
+              Added a section on multi-word nouns with a limit of three words.
+            </para>
+          </listitem>
+          <listitem>
+            <para>
+              Added a section on phrasal verbs, listing the ones that remain accepted.
+            </para>
+          </listitem>
+          <listitem>
+            <para>
+              Added a section on pronouns, including sentence-initial <quote>this</quote> and
+              <quote>that.</quote>
+            </para>
+          </listitem>
+          <listitem>
+            <para>
+              Added a section on terminology consistency: one term for one thing, and consistent
+              phrasing for recurring actions.
+            </para>
+          </listitem>
+          <listitem>
+            <para>
+              Added a section on verbs: do not use names as verbs, prefer verbs over
+              nominalizations, and keep the conjunction <quote>that.</quote>
+            </para>
+          </listitem>
+          </itemizedlist>
+        </revdescription>
+      </revision>
       <revision><date>2025-06-04</date>
         <revdescription>
           <para/>
@@ -25,8 +70,7 @@
   <para>
     When in doubt about the spelling or usage of a word, first see
     <xref linkend="app-terminology"/>. If the usage of a word is not regulated there, use the
-    preferred spelling from <link xlink:href="https://www.merriam-webster.com/"/>
-    (<link xlink:href="https://www.m-w.com/"/> for short).
+    preferred spelling from <link xlink:href="https://www.merriam-webster.com/"/>.
   </para>
   <para>
     The correct spelling of &suse; product names is listed in the terminology table
@@ -107,8 +151,8 @@
     </para>
     <para>
       In a series of items, the position of the article changes the meaning. In <quote>Restart the
-      new services, timers, and sockets,</quote> all three are new. In <quote>Restart the new
-      services, the timers, and the sockets,</quote> only the services are new. Repeat the article
+      new services, timers and sockets,</quote> all three are new. In <quote>Restart the new
+      services, the timers and the sockets,</quote> only the services are new. Repeat the article
       before every item when the modifier applies to the first item only.
     </para>
     <para>
@@ -369,27 +413,15 @@
   <section xml:id="sec-jargon">
     <title>Jargon and slang</title>
     <para>
-      Do not use jargon, slang, or regional expressions. Many of our readers do not have English as
+      Do not use jargon, slang or regional expressions. Many of our readers do not have English as
       a first language, and such terms are hard to translate and easy to misunderstand. Use a plain
       technical term instead:
     </para>
     <itemizedlist>
       <listitem>
         <para>
-          Instead of <quote>to brick a device,</quote> write <quote>to make a device
-          unusable.</quote>
-        </para>
-      </listitem>
-      <listitem>
-        <para>
           Instead of <quote>to nuke</quote> or <quote>to blow away,</quote> write <quote>to
           delete</quote> or <quote>to remove.</quote>
-        </para>
-      </listitem>
-      <listitem>
-        <para>
-          Instead of <quote>to spin up an instance,</quote> write <quote>to create an
-          instance</quote> or <quote>to start an instance.</quote>
         </para>
       </listitem>
       <listitem>
@@ -405,13 +437,13 @@
       </listitem>
     </itemizedlist>
     <para>
-      Do not use humor, irony, or cultural references, such as references to films, sports, or
+      Do not use humor, irony or cultural references, such as references to films, sports or
       holidays. They rarely translate and can exclude readers. For more information, see
       <xref linkend="sec-bias"/>.
     </para>
     <para>
       A technical term is not jargon. Terms such as <literal>container</literal>,
-      <literal>inode</literal>, or <literal>snapshot</literal> are correct in the right context.
+      <literal>inode</literal> or <literal>snapshot</literal> are correct in the right context.
       If a term is new to the intended audience, define it at first use.
     </para>
   </section>
@@ -458,7 +490,7 @@
     </itemizedlist>
     <para>
       This rule does not apply to names that you must not change, such as product names, command
-      names, or user interface labels. Do not shorten or hyphenate them.
+      names or user interface labels. Do not shorten or hyphenate them.
     </para>
   </section>
   <section xml:id="sec-number">
@@ -509,11 +541,6 @@
     <itemizedlist>
       <listitem>
         <para>
-          Instead of <quote>to bring up,</quote> write <quote>to start.</quote>
-        </para>
-      </listitem>
-      <listitem>
-        <para>
           Instead of <quote>to carry out,</quote> write <quote>to perform</quote> or <quote>to
           run.</quote>
         </para>
@@ -528,27 +555,11 @@
           Instead of <quote>to look into,</quote> write <quote>to investigate.</quote>
         </para>
       </listitem>
-      <listitem>
-        <para>
-          Instead of <quote>to go through,</quote> write <quote>to review.</quote>
-        </para>
-      </listitem>
-      <listitem>
-        <para>
-          Instead of <quote>to get rid of,</quote> write <quote>to remove</quote> or <quote>to
-          delete.</quote>
-        </para>
-      </listitem>
-      <listitem>
-        <para>
-          Instead of <quote>to take out,</quote> write <quote>to remove.</quote>
-        </para>
-      </listitem>
-    </itemizedlist>
+     </itemizedlist>
     <para>
       Some phrasal verbs are the established technical term for an action, and no single-word verb
-      replaces them. Use them as they are listed in <xref linkend="app-terminology"/>, for example
-      <quote>to log in to,</quote> <quote>to set up,</quote> <quote>to shut down,</quote> and
+      replaces them. Use them as they are listed in <xref linkend="app-terminology"/>, for example,
+      <quote>to log in to,</quote> <quote>to set up,</quote> <quote>to shut down</quote> and
       <quote>to back up.</quote> Do not replace them with a single-word verb.
     </para>
   </section>
@@ -577,7 +588,7 @@
       than one noun that the pronoun can refer to, repeat the noun instead.
     </para>
     <para>
-      Do not start a sentence with <quote>this,</quote> <quote>that,</quote> <quote>these,</quote>
+      Do not start a sentence with <quote>this,</quote> <quote>that,</quote> <quote>these</quote>
       or <quote>it</quote> to refer to the whole of the previous sentence. Name the thing that you
       refer to. Write <quote>The service reads the file at start-up. This behavior prevents
       changes at runtime.</quote> instead of <quote>The service reads the file at start-up. This
@@ -656,7 +667,7 @@
     <title>Sentence structure</title>
     <para>
       Form clear and direct sentences. Avoid complicated clauses. Make sure that the relationship
-      between subject, verb, and object is clear. Avoid joining sentences with semicolons. Avoid
+      between subject, verb and object is clear. Avoid joining sentences with semicolons. Avoid
       ending sentences with prepositions.
     </para>
     <para>
@@ -679,7 +690,7 @@
     </itemizedlist>
     <para>
       Write one instruction in a step. Use the imperative form: write <quote>Enter the user
-      name.</quote> instead of <quote>The user name must be entered.</quote> Describe two actions
+      name.</quote> instead of <quote>The user name should be entered.</quote> Describe two actions
       in the same step only if the actions occur at the same time, or if a result follows
       immediately from the action. For example, a command and the output that the command returns
       belong in the same step.
@@ -689,49 +700,6 @@
       disk, unmount the file system.</quote> instead of <quote>Before you remove the disk, you must
       unmount the file system.</quote> An exception is a safety-critical instruction, where
       <quote>must</quote> can show the reader that the instruction is important.
-    </para>
-    <para>
-      To check the length of a sentence, count each of the following as one word:
-    </para>
-    <itemizedlist>
-      <listitem>
-        <para>
-          A number, or a number together with its unit of measurement, such as
-          <literal>4 GB</literal>.
-        </para>
-      </listitem>
-      <listitem>
-        <para>
-          An abbreviation or an acronym.
-        </para>
-      </listitem>
-      <listitem>
-        <para>
-          A command, an option, a file name, or a path, such as
-          <command>systemctl daemon-reload</command>.
-        </para>
-      </listitem>
-      <listitem>
-        <para>
-          A user interface label, such as <guimenu>User and group management</guimenu>.
-        </para>
-      </listitem>
-      <listitem>
-        <para>
-          A hyphenated compound, such as <emphasis>read-only</emphasis>.
-        </para>
-      </listitem>
-      <listitem>
-        <para>
-          Text in parentheses. Count the text in the parentheses a second time, as a sentence of
-          its own.
-        </para>
-      </listitem>
-    </itemizedlist>
-    <para>
-      Do not count numbers that identify steps, sections, or figures. A colon that introduces a
-      list ends the sentence: count the text before the colon as one sentence and each list item as
-      a separate sentence. The word limit applies to each of them.
     </para>
     <para>
       Avoid using parentheses. Where they are necessary, move them to the end of the sentence.
@@ -779,7 +747,7 @@
       Use the same phrasing for actions that recur. For example, always write <quote>Confirm with
       <guimenu>OK</guimenu>.</quote> or always write <quote>Click
       <guimenu>OK</guimenu>.</quote>&mdash;do not alternate between them. Consistent phrasing lets
-      translation memory reuse existing translations, which reduces cost and keeps the translated
+      translation memory reuse existing translations and keeps the translated
       documentation consistent.
     </para>
   </section>
@@ -856,9 +824,7 @@
       When referring to UI labels, capitalize them exactly as in the UI itself. Software created at
       &suse; (such as YaST or Uyuni) should use sentence-style capitalization. If it does not, you
       can make aware the developers of that software. For more information about sentence-style
-      capitalization, see <xref linkend="sec-capitalization-sentence"/> and the
-      <link xlink:href="https://productbrand.suse.com/writing/conventions-and-rules">&suse; Product
-      Brand guide</link>.
+      capitalization, see <xref linkend="sec-capitalization-sentence"/>.
     </para>
     <para>
       For more information about markup for UI labels, see
@@ -868,7 +834,7 @@
   <section xml:id="sec-verb">
     <title>Verbs</title>
     <para>
-      Do not use a product name, a command name, or a user interface label as a verb. Write
+      Do not use a product name, a command name or a user interface label as a verb. Write
       <quote>Use <command>rsync</command> to copy the directory.</quote> instead of <quote>Rsync
       the directory.</quote> Names are nouns, and a reader who does not know the name cannot see
       which action you describe.

--- a/xml/docu_styleguide.structure.xml
+++ b/xml/docu_styleguide.structure.xml
@@ -160,7 +160,35 @@
           the documentation.
         </para>
       </listitem>
+      <listitem>
+        <para>
+          State the consequence in concrete terms. Write <quote>Formatting a mounted file system
+          destroys all data on it.</quote> instead of <quote>Take care when you format file
+          systems.</quote>
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          If the content fits more than one type of admonition, use the most severe type.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          <emphasis outputformat="db"><tag class="emptytag">note</tag> or
+          <tag class="emptytag">tip</tag>:</emphasis><phrase
+          outputformat="adoc"><emphasis>NOTE</emphasis>
+          or <emphasis>TIP</emphasis>:</phrase> Give information only. Do not put an instruction, a
+          requirement, or a limit in a note or a tip. If the reader must perform an action, write
+          the action as a step of the procedure. If not performing the action leads to data loss or
+          damage, write a warning instead.
+        </para>
+      </listitem>
     </itemizedlist>
+    <para>
+      To find out whether a procedure uses notes and tips correctly, read the procedure without
+      them. If the reader can still complete the task correctly, the notes and tips are used
+      correctly. If information is missing, move that information into a step.
+    </para>
     <example xml:id="ex-warning-source" outputformat="db">
       <title>An example of a warning (source)</title>
 <screen>&lt;warning&gt;
@@ -2672,7 +2700,8 @@ System:: Get a basic understanding of the system components.</screen>
       <listitem>
         <para>
           Short, simple steps and, if necessary, substeps describing the actions to be performed.
-          See also <xref linkend="sec-structure-sentence"/>.
+          Write one instruction in a step, in the imperative form, and use a maximum of 20 words in
+          a sentence. See also <xref linkend="sec-structure-sentence"/>.
         </para>
       </listitem>
     </itemizedlist>

--- a/xml/docu_styleguide.structure.xml
+++ b/xml/docu_styleguide.structure.xml
@@ -8,6 +8,35 @@
   <title>Structure and markup</title>
   <info>
     <revhistory xml:id="rh-structure">
+      <revision><date>2026-08-14</date>
+        <revdescription>
+          <itemizedlist>
+            <listitem>
+              <para>
+                Added a section on paragraph structure: topic sentences, one topic per paragraph, and
+                a maximum of six sentences.
+              </para>
+            </listitem>
+            <listitem>
+              <para>
+                Split the sentence length limit into 25 words for running text and 20 words for
+                procedure steps, and added rules for counting words.
+              </para>
+            </listitem>
+            <listitem>
+              <para>
+                Added a rule to write one instruction per step, in the imperative form.
+              </para>
+            </listitem>
+            <listitem>
+              <para>
+                Clarified that notes and tips give information only and must not contain instructions,
+                requirements or limits.
+              </para>
+            </listitem>
+         </itemizedlist>
+        </revdescription>
+      </revision>
       <revision><date>2025-06-04</date>
         <revdescription>
           <para/>
@@ -178,17 +207,12 @@
           <tag class="emptytag">tip</tag>:</emphasis><phrase
           outputformat="adoc"><emphasis>NOTE</emphasis>
           or <emphasis>TIP</emphasis>:</phrase> Give information only. Do not put an instruction, a
-          requirement, or a limit in a note or a tip. If the reader must perform an action, write
+          requirement or a limit in a note or a tip. If the reader must perform an action, write
           the action as a step of the procedure. If not performing the action leads to data loss or
           damage, write a warning instead.
         </para>
       </listitem>
     </itemizedlist>
-    <para>
-      To find out whether a procedure uses notes and tips correctly, read the procedure without
-      them. If the reader can still complete the task correctly, the notes and tips are used
-      correctly. If information is missing, move that information into a step.
-    </para>
     <example xml:id="ex-warning-source" outputformat="db">
       <title>An example of a warning (source)</title>
 <screen>&lt;warning&gt;
@@ -882,7 +906,7 @@ See &lt;&lt;sec-cross-reference&gt;&gt;.</screen>
       custom <quote>named</quote> <tag class="attribute">xrefstyle</tag> attributes that require
       support from the style sheets. For more info, refer to
       <link
-       xlink:href="http://www.sagehill.net/docbookxsl/CustomXrefs.html">DocBook XSL:
+       xlink:href="https://sagehill.net/docbookxsl/CustomXrefs.html">DocBook XSL:
       The Complete Guide: Customizing cross-references</link>.
     </para>
     <para>

--- a/xml/docu_styleguide.terminology.xml
+++ b/xml/docu_styleguide.terminology.xml
@@ -8,6 +8,11 @@
   <title>Terminology and general vocabulary</title>
   <info>
     <revhistory xml:id="rh-app-terminology">
+      <revision><date>2026-08-14</date>
+        <revdescription>
+          <para>Added entries for jargon and phrasal verbs to the general vocabulary table.</para>
+        </revdescription>
+      </revision>
       <revision><date>2025-06-04</date>
         <revdescription>
           <para/>

--- a/xml/docu_styleguide.terminology.xml
+++ b/xml/docu_styleguide.terminology.xml
@@ -2208,6 +2208,11 @@
             </entry>
           </row>
           <row>
+            <entry>by default, without additional configuration</entry>
+            <entry>out of the box [jargon]</entry>
+            <entry>adverbial phrase</entry>
+          </row>
+          <row>
             <entry>cannot</entry>
             <entry>can't [contraction], can not</entry>
             <entry>verb</entry>
@@ -2229,10 +2234,26 @@
             </entry>
           </row>
           <row>
+            <entry>(to) create sth., (to) start sth.</entry>
+            <entry>(to) spin sth. up [jargon]</entry>
+            <entry>verb</entry>
+          </row>
+          <row>
             <entry>data is</entry>
             <entry>data are</entry>
             <entry>noun with verb; use all other verbs in the singular
               </entry>
+          </row>
+          <row>
+            <entry>(to) delete sth., (to) remove sth.</entry>
+            <entry>(to) nuke sth. [jargon], (to) blow sth. away [jargon],
+              (to) get rid of sth.</entry>
+            <entry>verb</entry>
+          </row>
+          <row>
+            <entry>(to) determine sth.</entry>
+            <entry>(to) figure sth. out</entry>
+            <entry>verb</entry>
           </row>
           <row>
             <entry/>
@@ -2268,6 +2289,16 @@
             </entry>
           </row>
           <row>
+            <entry>internally</entry>
+            <entry>under the hood [jargon]</entry>
+            <entry>adverb</entry>
+          </row>
+          <row>
+            <entry>(to) investigate sth.</entry>
+            <entry>(to) look into sth.</entry>
+            <entry>verb</entry>
+          </row>
+          <row>
             <entry>inward</entry>
             <entry>inwards [BrE]</entry>
             <entry>adverb
@@ -2277,6 +2308,11 @@
             <entry/>
             <entry>just [filler]</entry>
             <entry>adjective, adverb; avoid</entry>
+          </row>
+          <row>
+            <entry>(to) make sth. unusable</entry>
+            <entry>(to) brick sth. [jargon]</entry>
+            <entry>verb</entry>
           </row>
           <row>
             <entry>might</entry>
@@ -2310,9 +2346,24 @@
       </entry>
           </row>
           <row>
+            <entry>(to) perform sth., (to) run sth.</entry>
+            <entry>(to) carry sth. out</entry>
+            <entry>verb</entry>
+          </row>
+          <row>
             <entry/>
             <entry>please</entry>
             <entry>adverb; avoid</entry>
+          </row>
+          <row>
+            <entry>(to) remove sth.</entry>
+            <entry>(to) take sth. out</entry>
+            <entry>verb</entry>
+          </row>
+          <row>
+            <entry>(to) review sth.</entry>
+            <entry>(to) go through sth.</entry>
+            <entry>verb</entry>
           </row>
           <row>
             <entry/>
@@ -2339,6 +2390,11 @@
             <entry>(to) simplify sth.</entry>
             <entry>(to) ease sth., (to) facilitate sth.</entry>
             <entry>verb; avoid</entry>
+          </row>
+          <row>
+            <entry>(to) start sth.</entry>
+            <entry>(to) bring sth. up</entry>
+            <entry>verb</entry>
           </row>
           <row>
             <entry/>

--- a/xml/product-entities.ent
+++ b/xml/product-entities.ent
@@ -4,7 +4,7 @@
 <!-- PRODUCT NAME AND VERSIONS -->
 <!ENTITY productname            "<phrase xmlns='http://docbook.org/ns/docbook'>&suse; Documentation Style Guide (<phrase outputformat='db'>DocBook</phrase><phrase outputformat='adoc'>AsciiDoc</phrase>)</phrase>">
 <!ENTITY productnameshort       "ACRONYM">
-<!ENTITY productnumber          "2026-06">
+<!ENTITY productnumber          "2026-08">
 
 
 <!-- PROJECT REPOSITORY URL -->


### PR DESCRIPTION
Adopts rules from ASD-STE100 Simplified Technical English that apply to SUSE technical documentation #345.

## Licensing note

The STE specification grants free reuse only to ASD/AIA/AIAC/ICCAIA members and a few other named categories, which SUSE does not clearly fall into. No STE text or examples are reproduced here — every rule is restated in our own wording, with Linux and SUSE examples.

## Language chapter

- New **Paragraphs** section: topic sentences, one topic per paragraph, maximum six sentences. Also notes the retrieval benefit for search engines and AI assistants, cross-referencing the Web writing chapter.
- **Sentence structure** reworked: the flat 25-word limit is split into 25 words for running text and 20 words for procedure steps, with rules for what counts as one word. Adds one instruction per step in the imperative, and the rule against combining "must" with an imperative.
- New **Articles** section: do not omit articles, no article before a noun with an identifier ("see step 3"), and article placement in a series.
- New **Jargon and slang** section.
- New **Multi-word nouns** section: maximum three words, with three remedies.
- New **Phrasal verbs** section.
- New **Pronouns** section, including sentence-initial "this"/"that" referring to a whole clause.
- New **Terminology consistency** section: one term for one thing, plus consistent phrasing for recurring actions, which lets translation memory reuse existing translations.
- New **Verbs** section: names are not verbs, verbs instead of nominalizations, and keeping the conjunction "that".

## Structure chapter

- **Admonitions**: state consequences in concrete terms, escalate to the most severe applicable type, and keep instructions, requirements, and limits out of notes and tips. The existing guidance on admonition titles and paragraph order is unchanged.
- **Procedures**: cross-references the new step length and imperative rules.

## Terminology appendix

Twelve rows added to the general vocabulary table, in alphabetical position, covering the jargon and phrasal verbs the new sections reject.
